### PR TITLE
Don't override platform list default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,6 @@ on:
         description: 'A comma-separated list of platforms to build for. Do not include spaces. If not provided, will use the default list of platform supported by OpenVox.'
         required: false
         type: string
-        # At the moment, a couple platforms end up timing out at the 6 hour hard limit for runners
-        # due to using emulation and puppet-runtime taking a long time to compile to begin with.
-        # We'll build these locally for the time being, so override the the default list of platforms.
-        # Remove this default once we are using self-hosted runners.
-        #
-        # The ones that need to be run locally are amazon-2023-aarch64, fedora-40-aarch64, and el-10-aarch64
-        default: 'amazon-2-aarch64,amazon-2023-x86_64,debian-10-amd64,debian-11-aarch64,debian-11-amd64,debian-12-aarch64,debian-12-amd64,el-7-x86_64,el-8-aarch64,el-8-x86_64,el-8-ppc64le,el-9-aarch64,el-9-x86_64,el-9-ppc64le,el-10-x86_64,fedora-36-x86_64,fedora-40-x86_64,sles-15-x86_64,ubuntu-18.04-aarch64,ubuntu-18.04-amd64,ubuntu-20.04-aarch64,ubuntu-20.04-amd64,ubuntu-22.04-aarch64,ubuntu-22.04-amd64,ubuntu-24.04-aarch64,ubuntu-24.04-amd64'
 
 jobs:
   build:


### PR DESCRIPTION
We now don't have issues building ARM platforms since we have ARM runners, so remove overriding the default list.