### PR TITLE
Changes for Windows OpenVox builds

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -60,7 +60,9 @@ elsif platform.is_windows?
   pkg.environment "PATH", "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:tools_root]}/bin):$(shell cygpath -u #{settings[:tools_root]}/include):$(shell cygpath -u #{settings[:bindir]}):$(shell cygpath -u #{ruby_bindir}):$(shell cygpath -u #{settings[:includedir]}):$(PATH)"
   pkg.environment 'CYGWIN', settings[:cygwin]
   pkg.environment 'LDFLAGS', settings[:ldflags]
-  pkg.environment 'optflags', settings[:cflags] + ' -O3'
+  optflags = settings[:cflags] + ' -O3'
+  pkg.environment 'optflags', optflags
+  pkg.environment 'CFLAGS', optflags
 elsif platform.is_macos?
   pkg.environment 'optflags', settings[:cflags]
   if platform.is_cross_compiled?

--- a/configs/components/boost.rb
+++ b/configs/components/boost.rb
@@ -1,7 +1,15 @@
 component "boost" do |pkg, settings, platform|
   # Source-Related Metadata
-  pkg.version "1.73.0"
-  pkg.md5sum "4036cd27ef7548b8d29c30ea10956196"
+  # Only updating for Windows because we have to in order to compile it
+  # under modern Cygwin. Leaving the old version out of an abundance of
+  # caution for everything else until we have proper testing in place.
+  if platform.is_windows?
+    pkg.version "1.82.0"
+    pkg.md5sum "f7050f554a65f6a42ece221eaeec1660"
+  else
+    pkg.version "1.73.0"
+    pkg.md5sum "4036cd27ef7548b8d29c30ea10956196"
+  end
   # Apparently boost doesn't use dots to version they use underscores....arg
   pkg.url "http://downloads.sourceforge.net/project/boost/boost/#{pkg.get_version}/boost_#{pkg.get_version.gsub('.','_')}.tar.gz"
   pkg.mirror "#{settings[:buildsources_url]}/boost_#{pkg.get_version.gsub('.','_')}.tar.gz"
@@ -87,19 +95,19 @@ component "boost" do |pkg, settings, platform|
     pkg.environment("LD_LIBRARY_PATH", '/opt/pl-build-tools/lib') if platform.name =~ /solaris-10/
   elsif platform.is_windows?
     arch = platform.architecture == "x64" ? "64" : "32"
-    pkg.environment "PATH", "C:/tools/mingw#{arch}/bin:$(PATH)"
+    pkg.environment "PATH", "#{settings[:gcc_bindir]}:$(PATH)"
     pkg.environment "CYGWIN", "nodosfilewarning"
-    b2location = "#{settings[:prefix]}/bin/b2.exe"
-    bjamlocation = "#{settings[:prefix]}/bin/bjam.exe"
+    b2location = "#{settings[:prefix]}/b2.exe"
+    bjamlocation = "#{settings[:prefix]}/bjam.exe"
     # bootstrap.bat does not take the `--with-toolset` flag
     toolset = "gcc"
-    with_toolset = ""
+    with_toolset = "mingw"
     # we do not need to reference the .bat suffix when calling the bootstrap script
     bootstrap_suffix = ""
     # we need to make sure we link against non-cygwin libraries
     execute = "cmd.exe /c "
 
-    gpp = "C:/tools/mingw#{arch}/bin/g++"
+    gpp = "x86_64-w64-mingw32-g++.exe"
 
     # Set the address model so we only build one arch
     #

--- a/configs/components/git.rb
+++ b/configs/components/git.rb
@@ -13,14 +13,7 @@ component "git" do |pkg, settings, platform|
     pkg.mirror "#{settings[:buildsources_url]}/git-#{pkg.get_version}.tar.gz"
   end
 
-  if platform.is_windows?
-    pkg.environment "PATH", [
-      "$(shell cygpath -u \"C:\\ProgramData\\chocolatey\\bin\")",
-      "$(PATH)",
-    ].join(':')
-  else
-    pkg.build_requires 'curl'
-  end
+  pkg.build_requires 'curl' unless platform.is_windows?
 
   build_deps = []
 

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -10,8 +10,6 @@ component 'openssl' do |pkg, settings, platform|
 
   if platform.name =~ /^(el-|redhat-|redhatfips-|fedora-)/
     pkg.build_requires 'perl-core'
-  elsif platform.is_windows?
-    pkg.build_requires 'strawberryperl'
   elsif platform.is_solaris?
     # perl is installed in platform definition
   else

--- a/configs/components/ruby-3.2.7.rb
+++ b/configs/components/ruby-3.2.7.rb
@@ -48,7 +48,6 @@ component 'ruby-3.2.7' do |pkg, settings, platform|
 
   if platform.is_windows?
     pkg.apply_patch "#{base}/windows_mingw32_mkmf.patch"
-    pkg.apply_patch "#{base}/windows_nocodepage_utf8_fallback_r2.5.patch"
     pkg.apply_patch "#{base}/ruby-faster-load_32.patch"
     pkg.apply_patch "#{base}/revert_speed_up_rebuilding_loaded_feature_index.patch"
     pkg.apply_patch "#{base}/revert-ruby-double-load-symlink.patch"
@@ -69,7 +68,9 @@ component 'ruby-3.2.7' do |pkg, settings, platform|
     pkg.environment 'optflags', settings[:cflags]
     pkg.environment 'PATH', '$(PATH):/opt/homebrew/bin:/usr/local/bin'
   elsif platform.is_windows?
-    pkg.environment 'optflags', settings[:cflags] + ' -O3'
+    optflags = settings[:cflags] + ' -O3'
+    pkg.environment 'optflags', optflags
+    pkg.environment 'CFLAGS', optflags
     pkg.environment 'MAKE', 'make'
   elsif platform.is_cross_compiled?
     pkg.environment 'CROSS_COMPILING', 'true'

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -69,7 +69,6 @@ component "runtime-agent" do |pkg, settings, platform|
     # To exist inside our vendored ruby
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll", "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libiconv-2.dll", "#{settings[:ruby_bindir]}/libiconv-2.dll"
     pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
   elsif platform.is_solaris? ||
         platform.name =~ /el-[56]|redhatfips-7|sles-(:?11)/

--- a/configs/platforms/windows-2019-x64.rb
+++ b/configs/platforms/windows-2019-x64.rb
@@ -1,55 +1,49 @@
 platform "windows-2019-x64" do |plat|
   plat.vmpooler_template "win-2019-x86_64"
+  
+  # Not currently used
   plat.docker_image "windows:ltsc2019"
   plat.docker_registry "mcr.microsoft.com"
   plat.docker_arch "linux/amd64"
 
   plat.servicetype "windows"
-  visual_studio_version = '2017'
-  visual_studio_sdk_version = 'win8.1'
 
-  # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey-1.4.0.ps1"
-  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget"
-
-  # C:\tools is likely added by mingw, however because we also want to use that
-  # dir for vsdevcmd.bat we create it for safety
-  plat.provision_with "mkdir C:/tools"
-  # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey"
-
+  # Install ruby, ruby-devel, gcc-core, make, git, and libyaml-devel in Cygwin on the Windows image.
+  # Run setup.bat found in the root of this repo. These are needed in order to successfully
+  # do a bundle install. They are included here just in case they get removed somehow.
+  # Make sure "setup-x86_64.exe" (Cygwin's installer) is at the root of C:/
   packages = [
-    "cmake",
-    "pl-gdbm-#{self._platform.architecture}",
-    "pl-iconv-#{self._platform.architecture}",
-    "pl-libffi-#{self._platform.architecture}",
-    "pl-pdcurses-#{self._platform.architecture}",
-    "pl-toolchain-#{self._platform.architecture}",
-    "pl-zlib-#{self._platform.architecture}",
-    "mingw-w64 -version 5.2.0 -debug",
-    "Wix310 -version 3.10.2 -debug -x86"
+    'autoconf',
+    'cmake',
+    'gcc-core',
+    'gcc-g++',
+    'git',
+    'libyaml-devel',
+    'make',
+    'mingw64-x86_64-gcc-core',
+    'mingw64-x86_64-gcc-g++',
+    'mingw64-x86_64-gdbm',
+    'mingw64-x86_64-libffi',
+    'mingw64-x86_64-readline',
+    'mingw64-x86_64-zlib',
+    'ruby',
+    'ruby-devel',
+    'patch',
   ]
 
-  packages.each do |name|
-    plat.provision_with("C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress #{name}")
-  end
-  # We use cache-location in the following install because msvc has several long paths
-  # if we do not update the cache location choco will fail because paths get too long
-  plat.provision_with "C:/ProgramData/chocolatey/bin/choco.exe install msvc.#{visual_studio_version}-#{visual_studio_sdk_version}.sdk.en-us -y --cache-location=\"C:\\msvc\" --no-progress"
-  # The following creates a batch file that will execute the vsdevcmd batch file located within visual studio.
-  # We create the following batch file under C:\tools\vsdevcmd.bat so we can avoid using both the %ProgramFiles(x86)%
-  # evironment var, as well as any spaces in the path when executing things with cygwin. This makes command execution
-  # through cygwin much easier.
-  #
-  # Note that the unruly \'s in the following string escape the following sequence to literal chars: "\" and then \""
-  plat.provision_with "touch C:/tools/vsdevcmd.bat && echo \"\\\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\#{visual_studio_version}\\BuildTools\\Common7\\Tools\\vsdevcmd\\\"\" >> C:/tools/vsdevcmd.bat"
-
-  plat.install_build_dependencies_with "C:/ProgramData/chocolatey/bin/choco.exe install -y --no-progress"
+  plat.provision_with("C:/setup-x86_64.exe -q -P #{packages.join(',')}")
+  plat.install_build_dependencies_with "C:/setup-x86_64.exe -q -P"
 
   plat.make "/usr/bin/make"
   plat.patch "TMP=/var/tmp /usr/bin/patch.exe --binary"
 
   plat.platform_triple "x86_64-w64-mingw32"
+
+  # Putting these here as a reminder where we use them elsewhere. DO NOT
+  # use the full path, just the name of the executable without the extension.
+  # Otherwise, autoconf gets confused.
+  plat.environment 'CC', "x86_64-w64-mingw32-gcc"
+  plat.environment 'CXX', "x86_64-w64-mingw32-g++"
 
   plat.package_type "archive"
   plat.output_dir "windows"

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -155,17 +155,11 @@ else
 end
 
 if platform.is_windows?
-  arch = platform.architecture == "x64" ? "64" : "32"
-  proj.setting(:gcc_root, "C:/tools/mingw#{arch}")
-  proj.setting(:vs_version, '2017')
-  # The msbuild command needs to be surrounded in quotes and shelled
-  # out to cmd.exe because otherwise cygwin will treat the && in bash and
-  # fail. Even though the invocation of msbuild is in quotes, parameters
-  # sent to it don't need extra quotes or escaping.
-  proj.setting(:msbuild, "cmd.exe /C \"C:/tools/vsdevcmd.bat && msbuild\"")
+  proj.setting(:gcc_root, "/usr/x86_64-w64-mingw32/sys-root/mingw")
   proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
-  proj.setting(:tools_root, "C:/tools/pl-build-tools")
-  proj.setting(:cppflags, "-I#{proj.tools_root}/include -I#{proj.gcc_root}/include -I#{proj.includedir}")
+  proj.setting(:tools_root, "/usr/x86_64-w64-mingw32/sys-root/mingw")
+  # If tools_root ever differs from gcc_root again, add it back here.
+  proj.setting(:cppflags, "-I#{proj.gcc_root}/include -I#{proj.gcc_root}/include/readline -I#{proj.includedir}")
   proj.setting(:cflags, "#{proj.cppflags}")
 
   ldflags = "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat"

--- a/configs/projects/agent-runtime-main.rb
+++ b/configs/projects/agent-runtime-main.rb
@@ -80,6 +80,12 @@ project 'agent-runtime-main' do |proj|
   proj.component 'rubygem-erubi'
   proj.component 'rubygem-prime'
 
-  proj.component 'boost' if ENV['NO_PXP_AGENT'].to_s.empty?
-  proj.component 'yaml-cpp' if ENV['NO_PXP_AGENT'].to_s.empty?
+  # We are currently not building pxp-agent for Windows because it is unused for
+  # OpenVox aside from execution_wrapper which is soon to be replaced, and because
+  # we're having trouble getting things compiled correctly with the modern toolchain.
+  # For a Windows, only build these if BUILD_WINDOWS_PXP_AGENT is set.
+  # For other platforms, build these unless NO_PXP_AGENT is set.
+  build_for_pxp_agent = platform.is_windows? ? !ENV['BUILD_WINDOWS_PXP_AGENT'].to_s.empty? : ENV['NO_PXP_AGENT'].to_s.empty?
+  proj.component 'boost' if build_for_pxp_agent
+  proj.component 'yaml-cpp' if build_for_pxp_agent
 end

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,1 @@
+C:\setup-x86_64.exe -q -P ruby,ruby-devel,gcc-core,make,git,libyaml-devel

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -1,4 +1,5 @@
 require 'open3'
+require 'fileutils'
 
 namespace :vox do
   desc 'Build vanagon project with Docker'
@@ -12,8 +13,10 @@ namespace :vox do
     abort 'You must provide a platform.' if args[:platform].nil? || args[:platform].empty?
     platform = args[:platform]
 
-    engine = platform =~ /^osx-/ ? 'local' : 'docker'
+    engine = platform =~ /^(osx|windows)-/ ? 'local' : 'docker'
     cmd = "bundle exec build #{project} #{platform} --engine #{engine}"
+
+    FileUtils.rm_rf('C:/ProgramFiles64Folder/') if platform =~ /^windows-/
 
     puts "Running #{cmd}"
     exitcode = nil


### PR DESCRIPTION
These changes allow us to build puppet-runtime for windows-2019-x64 (really, any Windows flavor, but we'll use this platform string for now). The builder image is simply any version of current-ish Windows (I used Windows Server 2022 and Windows 11 for testing these changes).

To prep the image:
Put the Cygwin installer at C:\setup-x86_64.EXE
At the base of this repo, run setup.bat.

This also bumps Boost to 1.82.0 for Windows only.  This was necessary in order to fix a bug in building on Windows with Cygwin. https://github.com/boostorg/locale/commit/41868c62a0519799696b544518f1efd831ff71c2

However, I still don't have pxp-agent building correctly for Windows. Likely we will just build it without for now. But leaving the changes in here in case we need them.