### PR TITLE
Set paths back to PuppetLabs/Puppet on Windows

### DIFF
--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -30,8 +30,11 @@ proj.setting(:artifactory_url, "https://artifactory.delivery.puppetlabs.net/arti
 proj.setting(:buildsources_url, "#{proj.artifactory_url}/generic/buildsources")
 
 if platform.is_windows?
+  # In order not to break people, we need to keep the paths Puppetlabs/Puppet
   proj.setting(:company_id, "VoxPupuli")
+  proj.setting(:pl_company_id, "PuppetLabs")
   proj.setting(:product_id, "OpenVox")
+  proj.setting(:pl_product_id, "Puppet")
   if platform.architecture == "x64"
     proj.setting(:base_dir, "ProgramFiles64Folder")
   else
@@ -39,8 +42,8 @@ if platform.is_windows?
   end
   # We build for windows not in the final destination, but in the paths that correspond
   # to the directory ids expected by WIX. This will allow for a portable installation (ideally).
-  proj.setting(:install_root, File.join("C:", proj.base_dir, proj.company_id, proj.product_id))
-  proj.setting(:sysconfdir, File.join("C:", "CommonAppDataFolder", proj.company_id))
+  proj.setting(:install_root, File.join("C:", proj.base_dir, proj.pl_company_id, proj.pl_product_id))
+  proj.setting(:sysconfdir, File.join("C:", "CommonAppDataFolder", proj.pl_company_id))
   proj.setting(:tmpfilesdir, "C:/Windows/Temp")
 else
   proj.setting(:install_root, "/opt/puppetlabs")

--- a/configs/projects/_shared-client-tools-runtime.rb
+++ b/configs/projects/_shared-client-tools-runtime.rb
@@ -30,7 +30,7 @@ end
 
 if platform.is_windows?
   # Windows Installer settings.
-  proj.setting(:company_id, "VoxPupuli")
+  proj.setting(:company_id, "PuppetLabs")
   proj.setting(:product_id, "Client")
   if platform.architecture == "x64"
     proj.setting(:base_dir, "ProgramFiles64Folder")

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -29,7 +29,7 @@ project 'bolt-runtime' do |proj|
   proj.identifier "org.voxpupuli"
 
   if platform.is_windows?
-    proj.setting(:company_id, "VoxPupuli")
+    proj.setting(:company_id, "PuppetLabs")
     proj.setting(:product_id, "Bolt")
     if platform.architecture == "x64"
       proj.setting(:base_dir, "ProgramFiles64Folder")

--- a/configs/projects/pdk-runtime.rb
+++ b/configs/projects/pdk-runtime.rb
@@ -32,7 +32,7 @@ project 'pdk-runtime' do |proj|
 
   if platform.is_windows?
     proj.setting(:base_dir, 'ProgramFiles64Folder')
-    proj.setting(:company_id, 'VoxPupuli')
+    proj.setting(:company_id, 'PuppetLabs')
     proj.setting(:product_id, 'DevelopmentKit')
     proj.setting(:install_root, File.join('C:', proj.base_dir, proj.company_id, proj.product_id))
     proj.setting(:prefix, proj.install_root)


### PR DESCRIPTION
Changing the metadata unintentionally broke some things because changing company_id and product_id changes the paths where things live, where some modules expect things to be. This creates different variables for the directories so we can separate that from the ID itself. This will require more changes in the openvox-agent repo.