### PR TITLE
Update libxslt to v1.1.43

### DIFF
--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -1,6 +1,6 @@
 component "libxslt" do |pkg, settings, platform|
-  pkg.version '1.1.42'
-  pkg.sha256sum '85ca62cac0d41fc77d3f6033da9df6fd73d20ea2fc18b0a3609ffb4110e1baeb'
+  pkg.version '1.1.43'
+  pkg.sha256sum '5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a'
 
   libxslt_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
   pkg.url "https://download.gnome.org/sources/libxslt/#{libxslt_version_y}/libxslt-#{pkg.get_version}.tar.xz"


### PR DESCRIPTION
https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.news ### Security

- [CVE-2025-24855] Fix use-after-free of XPath context node
- [CVE-2024-55549] Fix UAF related to excluded namespaces

### Bug fixes

- variables: Fix non-deterministic generated IDs