### PR TITLE
Gemfile: Remove Gemfile.local support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ vendor/*
 output/*
 .bundle
 gems
-Gemfile.local
 Gemfile.lock
 *.log
 ext/packaging

--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,3 @@ group(:development, optional: true) do
 end
 
 #gem 'rubocop', "~> 0.34.2"
-
-eval_gemfile("#{__FILE__}.local") if File.exist?("#{__FILE__}.local")


### PR DESCRIPTION
We don't use a Gemfile.local in this repository and dependabot refuse to parse it.


```
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+-------------------------------------------------------------------------------------------------------------------------------------------------------+
|                                                                        Errors                                                                         |
+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
| Type                          | Details                                                                                                               |
+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
| dependency_file_not_parseable | {                                                                                                                     |
|                               |   "message": "Dependabot only supports uninterpolated string arguments to eval_gemfile. Got `\"#{__FILE__}.local\"`", |
|                               |   "file-path": "/Gemfile"                                                                                             |
|                               | }                                                                                                                     |
+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
```