### PR TITLE
Add GitHub action to create GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,41 @@
+---
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - modulesync
+      - question
+      - skip-changelog
+      - wont-fix
+      - wontfix
+      - github_actions
+
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - backwards-incompatible
+
+    - title: New Features 🎉
+      labels:
+        - enhancement
+
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+        - bugfix
+
+    - title: Documentation Updates 📚
+      labels:
+        - documentation
+        - docs
+
+    - title: Dependency Updates ⬆️
+      labels:
+        - dependencies
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+---
+name: Gem Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions: {}
+
+jobs:
+  create-github-release:
+    # Prevent releases from forked repositories
+    if: github.repository_owner == 'OpenVoxProject'
+    needs: build-release
+    name: Create GitHub release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # clone repo and create release
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create --repo ${{ github.repository }} ${{ github.ref_name }} --generate-notes


### PR DESCRIPTION
This will create a GitHub Release *with changelog* for each pushed tag. We do the same in our ruby gems:
https://github.com/voxpupuli/gem-workflow-test