### PR TITLE
Release CI: Dont checkout the repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: write # clone repo and create release
     steps:
-      - uses: actions/checkout@v4
       - name: Create Release
         shell: bash
         env:


### PR DESCRIPTION
That's not required. Followup for https://github.com/OpenVoxProject/puppet-runtime/pull/26#pullrequestreview-2943242420