### PR TITLE
Revert "remove statics libs not needed after the build"

### DIFF
--- a/configs/components/augeas.rb
+++ b/configs/components/augeas.rb
@@ -136,7 +136,7 @@ component 'augeas' do |pkg, settings, platform|
 
 
   pkg.configure do
-    ["./configure #{extra_config_flags} --prefix=#{settings[:prefix]} #{settings[:host]} --disable-static"]
+    ["./configure #{extra_config_flags} --prefix=#{settings[:prefix]} #{settings[:host]}"]
   end
 
   pkg.build do

--- a/configs/components/curl.rb
+++ b/configs/components/curl.rb
@@ -53,7 +53,7 @@ component 'curl' do |pkg, settings, platform|
   end
 
   configure_options = []
-  configure_options << "--with-ssl=#{settings[:prefix]} --without-libpsl --disable-static"
+  configure_options << "--with-ssl=#{settings[:prefix]} --without-libpsl"
 
   # OpenSSL version 3.0 & up no longer ships by default the insecure algorithms
   # that curl's ntlm module depends on (md4 & des).

--- a/configs/components/libyaml.rb
+++ b/configs/components/libyaml.rb
@@ -47,8 +47,7 @@ component 'libyaml' do |pkg, settings, platform|
   pkg.install do
     [
       "#{platform[:make]} VERBOSE=1 -j$(shell expr $(shell #{platform[:num_cores]}) + 1) install",
-      "rm -rf #{settings[:datadir]}/doc/#{pkg.get_name}*",
-      "rm -f #{settings[:libdir]}/*.{la,a}"
+      "rm -rf #{settings[:datadir]}/doc/#{pkg.get_name}*"
     ]
   end
 end

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -178,7 +178,6 @@ component 'openssl' do |pkg, settings, platform|
   # Skip man and html docs
   install_commands << "#{platform[:make]} #{install_prefix} install_sw install_ssldirs"
   install_commands << "rm -f #{settings[:prefix]}/bin/c_rehash"
-  install_commands << "rm -f #{settings[:libdir]}/*.{la,a}"
 
   pkg.install do
     install_commands


### PR DESCRIPTION
Reverts OpenVoxProject/puppet-runtime#9

This ended up breaking Windows builds. While I don't think we saw breakage on Linux, I'm not 100% sure there are no other effects here, so reverting for now to be safe.