### PR TITLE
Fix regexes

### DIFF
--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -5,7 +5,7 @@
 # Condensed version, e.g. '2.4.3' -> '243'
 ruby_version_condensed = pkg.get_version.tr('.', '')
 # Y version, e.g. '2.4.3' -> '2.4'
-ruby_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+ruby_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2')
 
 pkg.mirror "#{settings[:buildsources_url]}/ruby-#{pkg.get_version}.tar.gz"
 pkg.url "https://cache.ruby-lang.org/pub/ruby/#{ruby_version_y}/ruby-#{pkg.get_version}.tar.gz"

--- a/configs/components/libxml2.rb
+++ b/configs/components/libxml2.rb
@@ -7,7 +7,7 @@ component "libxml2" do |pkg, settings, platform|
   pkg.version '2.13.8'
   pkg.sha256sum '277294cb33119ab71b2bc81f2f445e9bc9435b893ad15bb2cd2b0e859a0ee84a'
 
-  libxml2_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+  libxml2_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2')
   pkg.url "https://download.gnome.org/sources/libxml2/#{libxml2_version_y}/libxml2-#{pkg.get_version}.tar.xz"
   pkg.mirror "#{settings[:buildsources_url]}/libxml2-#{pkg.get_version}.tar.xz"
 

--- a/configs/components/libxslt.rb
+++ b/configs/components/libxslt.rb
@@ -7,7 +7,7 @@ component "libxslt" do |pkg, settings, platform|
   pkg.version '1.1.43'
   pkg.sha256sum '5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a'
 
-  libxslt_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+  libxslt_version_y = pkg.get_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2')
   pkg.url "https://download.gnome.org/sources/libxslt/#{libxslt_version_y}/libxslt-#{pkg.get_version}.tar.xz"
   pkg.mirror "#{settings[:buildsources_url]}/libxslt-#{pkg.get_version}.tar.xz"
 

--- a/configs/components/pl-ruby-patch.rb
+++ b/configs/components/pl-ruby-patch.rb
@@ -9,7 +9,7 @@
 component "pl-ruby-patch" do |pkg, settings, platform|
   if platform.is_cross_compiled?
 
-    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
+    ruby_version_y = settings[:ruby_version].gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2')
 
     pkg.add_source("file://resources/files/ruby/patch-hostruby.rb")
 

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -78,9 +78,9 @@ proj.setting(:ruby_dir, proj.prefix)
 proj.setting(:ruby_bindir, proj.bindir)
 
 raise "Couldn't find a :ruby_version setting in the project file" unless proj.ruby_version
-ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2.0')
-ruby_version_y = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2')
-ruby_version_x = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1')
+ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2.0')
+ruby_version_y = proj.ruby_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2')
+ruby_version_x = proj.ruby_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1')
 
 proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
 proj.setting(:ruby_vendordir, File.join(proj.libdir, "ruby", "vendor_ruby"))

--- a/configs/projects/bolt-runtime.rb
+++ b/configs/projects/bolt-runtime.rb
@@ -63,7 +63,7 @@ project 'bolt-runtime' do |proj|
     proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem"))
   end
 
-  ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2.0')
+  ruby_base_version = proj.ruby_version.gsub(/(\d+)\.(\d+)(\.\d+)?/, '\1.\2.0')
   proj.setting(:gem_home, File.join(proj.libdir, 'ruby', 'gems', ruby_base_version))
   proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local --bindir=#{proj.ruby_bindir}")
 


### PR DESCRIPTION
I missed fixing up several regexes, now that we are only defining the Ruby x.y version and omitting the z to make bumping the version easier.