### PR TITLE
Update webrick

### DIFF
--- a/configs/components/rubygem-webrick.rb
+++ b/configs/components/rubygem-webrick.rb
@@ -4,8 +4,8 @@
 #   https://github.com/ruby/webrick/releases
 #####
 component 'rubygem-webrick' do |pkg, settings, platform|
-  pkg.version '1.8.1'
-  pkg.md5sum 'e02304c5eafc47d2fb393bba891c538f'
+  pkg.version '1.8.2'
+  pkg.md5sum 'adbdcb13788330c40b54c1134bf5d7a7'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
Updates to the latest 1.8.x semver to mitigate [CVE-2025-6442 ](https://nvd.nist.gov/vuln/detail/CVE-2025-6442) and [CVE-2024-47220 ](https://nvd.nist.gov/vuln/detail/CVE-2024-47220)