### PR TITLE
Roll back fast_gettext to 2.4.0

### DIFF
--- a/configs/components/rubygem-fast_gettext.rb
+++ b/configs/components/rubygem-fast_gettext.rb
@@ -2,16 +2,12 @@
 # Component release information:
 #   https://rubygems.org/gems/fast_gettext
 #   https://github.com/grosser/fast_gettext/blob/master/CHANGELOG
+# 2025-09-08: We must keep this at 2.4.0 for now because r10k
+#   relies on gettext-setup, which pins fast_gettext ~> 2.1.
 #####
 component "rubygem-fast_gettext" do |pkg, settings, platform|
-  if settings[:ruby_version].to_f >= 3.0
-    pkg.version '4.1.0'
-    pkg.sha256sum '8e6b612676d601209662d2cd793ed4a067f834c8ca65ede793bacc9bcc1c2763'
-  else
-    # Remove this when we EOL OpenVox 7.x
-    pkg.version '2.4.0'
-    pkg.sha256sum 'fd26c4c406aa10be34f0fd2847ce3ffdc1e9d9798de87538594757bbb9175fbf'
-  end
+  pkg.version '2.4.0'
+  pkg.sha256sum 'fd26c4c406aa10be34f0fd2847ce3ffdc1e9d9798de87538594757bbb9175fbf'
 
   instance_eval File.read('configs/components/_base-rubygem.rb')
 


### PR DESCRIPTION
The r10k gem relies on puppetlabs/gettext-setup, which pins fast_gettext ~> 2.1. We'll need to figure out a better strategy here at some point, but for now, this rolls back to 2.4. There are no security-related changes between 2.4 and 4.1.