### PR TITLE
Add switch for uploading to S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: 'main'
+      upload_to_s3:
+        description: 'Whether to upload the built artifacts to S3. If false, the artifacts will only be uploaded as workflow artifacts.'
+        required: false
+        type: boolean
+        default: true
       use_dev:
         description: 'Use the "dev" branch of the shared-actions repo'
         required: false
@@ -38,6 +43,7 @@ jobs:
       project_name: ${{ inputs.project_name }}
       platform_list: ${{ inputs.platform_list }}
       vanagon_branch: ${{ inputs.vanagon_branch }}
+      upload_to_s3: ${{ inputs.upload_to_s3 }}
     secrets: inherit
   build_dev:
     if: ${{ github.event.inputs.use_dev == 'true' }}
@@ -47,4 +53,5 @@ jobs:
       project_name: ${{ inputs.project_name }}
       platform_list: ${{ inputs.platform_list }}
       vanagon_branch: ${{ inputs.vanagon_branch }}
+      upload_to_s3: ${{ inputs.upload_to_s3 }}
     secrets: inherit


### PR DESCRIPTION
When we're just testing things, we often don't need to upload things to S3 and can just download the artifacts directly from the job. This lets us disable uploading to S3 so we don't fill it with too much garbage.