### PR TITLE
Use native compilation for macos-all-x86_64

### DIFF
--- a/configs/components/_base-ruby-augeas.rb
+++ b/configs/components/_base-ruby-augeas.rb
@@ -63,15 +63,11 @@ if platform.is_solaris?
 elsif platform.is_cross_compiled?
   if platform.is_linux? || platform.is_macos?
     pkg.environment "RUBY", host_ruby
-    pkg.environment 'CC', 'clang -target arm64-apple-macos11' if platform.name =~ /osx-11/
-    pkg.environment 'CC', 'clang -target arm64-apple-macos12' if platform.name =~ /osx-12/
     ruby = "#{host_ruby} -r#{settings[:datadir]}/doc/rbconfig-#{ruby_version}-orig.rb"
     pkg.environment "LDFLAGS", settings[:ldflags]
   end
 elsif platform.is_macos?
-  if platform.architecture == 'arm64'
-    pkg.environment "PATH", "$(PATH):/opt/homebrew/bin"
-  end
+  pkg.environment "PATH", "$(PATH):/opt/homebrew/bin:/usr/local/bin"
   pkg.environment 'CC', settings[:cc]
   pkg.environment 'CFLAGS', settings[:cflags]
   pkg.environment "LDFLAGS", settings[:ldflags]

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -62,11 +62,7 @@ component 'openssl' do |pkg, settings, platform|
     pkg.environment 'CC', settings[:cc]
     pkg.environment 'MACOSX_DEPLOYMENT_TARGET', settings[:deployment_target]
 
-    target = if platform.architecture == "arm64"
-               'darwin64-arm64'
-             else
-               'darwin64-x86_64'
-             end
+    target = "darwin64-#{platform.architecture}"
   elsif platform.is_linux?
     pkg.environment 'PATH', '/opt/pl-build-tools/bin:$(PATH):/usr/local/bin'
 

--- a/configs/components/ruby-3.2.rb
+++ b/configs/components/ruby-3.2.rb
@@ -118,11 +118,6 @@ component 'ruby-3.2' do |pkg, settings, platform|
     # This normalizes the build string to something like AIX 7.1.0.0 rather
     # than AIX 7.1.0.2 or something
     special_flags += " --build=#{settings[:platform_triple]} "
-  elsif platform.is_cross_compiled? && platform.is_macos?
-    # When the target arch is aarch64, ruby incorrectly selects the 'ucontext' coroutine
-    # implementation instead of 'arm64', so specify 'amd64' explicitly
-    # https://github.com/ruby/ruby/blob/c9c2245c0a25176072e02db9254f0e0c84c805cd/configure.ac#L2329-L2330
-    special_flags += " --with-coroutine=arm64 "
   elsif platform.is_solaris? && platform.architecture == "sparc"
     unless platform.is_cross_compiled?
       # configure seems to enable dtrace because the executable is present,

--- a/configs/components/rubygem-nokogiri.rb
+++ b/configs/components/rubygem-nokogiri.rb
@@ -21,10 +21,5 @@ component 'rubygem-nokogiri' do |pkg, settings, _platform|
   pkg.environment "GEM_HOME", gem_home
   if platform.is_macos?
     pkg.environment "PKG_CONFIG_PATH", "#{settings[:libdir]}/pkgconfig"
-    if platform.is_cross_compiled?
-      pkg.install do
-        "rm -r #{gem_home}/gems/nokogiri-#{pkg.get_version}/ext/nokogiri/tmp"
-      end
-    end
   end
 end

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -13,14 +13,6 @@ component "runtime-agent" do |pkg, settings, platform|
         "zypper install -y pl-gcc8"
       end
     end
-  elsif platform.is_macos? && platform.is_cross_compiled?
-    if settings[:ruby_version] =~ /^3\./
-      pkg.install do
-        # These are dependencies of ruby@3.x, remove symlinks from /usr/local
-        # so our build doesn't use the wrong headers
-        "cd /etc/homebrew && su test -c '#{platform.brew} unlink openssl libyaml'"
-      end
-    end
   end
 
   if platform.is_cross_compiled?

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -95,7 +95,6 @@ platform_triple = "ppc64le-redhat-linux" if platform.architecture == "ppc64le"
 platform_triple = "powerpc64le-suse-linux" if platform.architecture == "ppc64le" && platform.name =~ /^sles-/
 platform_triple = "powerpc64le-linux-gnu" if platform.architecture == "ppc64el"
 platform_triple = "arm-linux-gnueabihf" if platform.architecture == "armhf"
-platform_triple = "aarch64-apple-darwin" if platform.is_cross_compiled? && platform.is_macos?
 
 # Ruby's build process needs a functional "baseruby". When native compiling,
 # ruby will build "miniruby" and use that as "baseruby". When cross compiling,
@@ -113,9 +112,6 @@ elsif platform.is_cross_compiled? && (platform.is_linux? || platform.is_solaris?
     proj.setting(:host_ruby, "/opt/pl-build-tools/bin/ruby")
     proj.setting(:host_gem, "/opt/pl-build-tools/bin/gem")
   end
-elsif platform.is_cross_compiled? && platform.is_macos?
-  proj.setting(:host_ruby, "/usr/local/opt/ruby@#{ruby_version_y}/bin/ruby")
-  proj.setting(:host_gem, "/usr/local/opt/ruby@#{ruby_version_y}/bin/gem")
 else
   proj.setting(:host_ruby, File.join(proj.ruby_bindir, "ruby"))
   proj.setting(:host_gem, File.join(proj.ruby_bindir, "gem"))
@@ -123,8 +119,6 @@ end
 
 if platform.is_cross_compiled_linux?
   host = "--host #{platform_triple}"
-elsif platform.is_cross_compiled? && platform.is_macos?
-  host = "--host aarch64-apple-darwin --build x86_64-apple-darwin --target aarch64-apple-darwin"
 elsif platform.is_solaris?
   if platform.architecture == 'i386'
     platform_triple = "#{platform.architecture}-pc-solaris2.#{platform.os_version}"

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -11,12 +11,6 @@ namespace :vox do
     abort 'You must provide a platform.' if args[:platform].nil? || args[:platform].empty?
     platform = args[:platform]
     os, _ver, arch = platform.match(/^(\w+)-([\w|\.]+)-(\w+)$/).captures
-    if os == 'macos'
-      shell = `uname -m`.chomp
-      ruby = `ruby -v`.chomp
-      abort "Detected shell arch: #{shell}. You must run this build from a #{arch} machine or shell. To do this on the current host, run 'arch -#{arch} /bin/bash'" if shell != arch
-      abort "Detected ruby: #{ruby}. You must run this build with a #{arch} Ruby version. To do this on the current host, install Ruby from an #{arch} shell via 'arch -#{arch} /bin/bash'." unless ruby =~ /#{arch}/
-    end
 
     engine = platform =~ /^(macos|windows)-/ ? 'local' : 'docker'
     cmd = "bundle exec build #{project} #{platform} --engine #{engine}"


### PR DESCRIPTION
The experiment to use Rosetta on an arm64 host to build macos-all-x86_64 didn't quite work out, so we're going to build on native x86_64 hosts instead.