### PR TITLE
Specify pkgconf for el10

### DIFF
--- a/configs/components/ruby-augeas.rb
+++ b/configs/components/ruby-augeas.rb
@@ -50,10 +50,10 @@ component 'ruby-augeas' do |pkg, settings, platform|
     build_commands = []
 
     extconf = "#{ruby} ext/augeas/extconf.rb"
-    # The pkg-config shim gets confused on Almalinux 9 that we are building on
+    # The pkg-config shim gets confused on Almalinux 9 and 10 that we are building on
     # due to the version of rpm being cranky about using our older OpenSSL version,
     # so bypass the shim and use pkgconf directly.
-    extconf += ' --with-pkg-config=/usr/bin/pkgconf' if platform.name =~ /el-9/
+    extconf += ' --with-pkg-config=/usr/bin/pkgconf' if platform.name =~ /el-(9|10)/
     build_commands << extconf
     build_commands << "#{platform[:make]} -e -j$(shell expr $(shell #{platform[:num_cores]}) + 1)"
 


### PR DESCRIPTION
The Almalinux 10 image has the same problem as 9 when we try using our OpenSSL 3.0 when building the augeas gem.