### PR TITLE
Use shared compiler settings for openbolt-runtime

### DIFF
--- a/configs/projects/_shared-compiler-settings.rb
+++ b/configs/projects/_shared-compiler-settings.rb
@@ -1,8 +1,8 @@
 # Define default CFLAGS and LDFLAGS for most platforms, and then
 # tweak or adjust them as needed.
-proj.setting(:cppflags, "-I#{proj.includedir} -I/opt/pl-build-tools/include")
+proj.setting(:cppflags, "-I#{proj.includedir}")
 proj.setting(:cflags, proj.cppflags)
-proj.setting(:ldflags, "-L#{proj.libdir} -L/opt/pl-build-tools/lib -Wl,-rpath=#{proj.libdir}")
+proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir}")
 
 # Platform specific overrides or settings, which may override the defaults
 

--- a/configs/projects/openbolt-runtime.rb
+++ b/configs/projects/openbolt-runtime.rb
@@ -65,9 +65,8 @@ project 'openbolt-runtime' do |proj|
 
   # Define default CFLAGS and LDFLAGS for most platforms, and then
   # tweak or adjust them as needed.
-  proj.setting(:cppflags, "-I#{proj.includedir}")
-  proj.setting(:cflags, proj.cppflags)
-  proj.setting(:ldflags, "-L#{proj.libdir} -Wl,-rpath=#{proj.libdir}")
+  # Load default compiler settings
+  instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 
   # Platform specific overrides or settings, which may override the defaults
   if platform.is_windows?


### PR DESCRIPTION
Since we've centralized and standardized the way we define some of the compiler settings, this adds the shared compiler default settings to openbolt-runtime. It also removes the usless declarations of pl-build-tools locations, since we don't use those.