### PR TITLE
Update rubygem components

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-aws-partitions' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.1194.0'
-  pkg.sha256sum 'dcc6c65735f4266b9cb14feee67afd2d345e01e5b87697f91ddc06e7603b0811'
+  pkg.version '1.1213.0'
+  pkg.sha256sum '5ec132d91d44ef2702125b8f71f0e4fc2cd7de040e02c5d0aefb87219fd2e05e'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-aws-sdk-core.rb
+++ b/configs/components/rubygem-aws-sdk-core.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-aws-sdk-core' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '3.239.2'
-  pkg.sha256sum 'a6801845ee0bdb061a3f9fb488136f3a585d51ff05b77063a9e228c9539cf239'
+  pkg.version '3.242.0'
+  pkg.sha256sum 'c17b3003acc78d80c1a8437b285a1cfc5e4d7749ce7821cf3071e847535a29a0'
   pkg.build_requires 'rubygem-aws-eventstream'
   pkg.build_requires 'rubygem-aws-partitions'
   pkg.build_requires 'rubygem-aws-sigv4'

--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-aws-sdk-ec2' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.585.0'
-  pkg.sha256sum '72656489064ef23d676beec39a8f0940bbb20d019605ae0b6c39aa11d38bb963'
+  pkg.version '1.597.0'
+  pkg.sha256sum 'b4da34246a2721040d00e086a0d2cf0abb4ac0666f692a425eaeae32fac0de02'
   pkg.build_requires 'rubygem-aws-sdk-core'
   pkg.build_requires 'rubygem-aws-sigv4'
   ### End automated maintenance section ###

--- a/configs/components/rubygem-faraday-multipart.rb
+++ b/configs/components/rubygem-faraday-multipart.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-faraday-multipart' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.1.1'
-  pkg.sha256sum '77a18ff40149030fd1aef55bb4fc7a67ce46419a8a3fcd010e28c2526e8d8903'
+  pkg.version '1.2.0'
+  pkg.sha256sum '7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757'
   pkg.build_requires 'rubygem-multipart-post'
   ### End automated maintenance section ###
 

--- a/configs/components/rubygem-faraday-retry.rb
+++ b/configs/components/rubygem-faraday-retry.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-faraday-retry' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '2.3.2'
-  pkg.sha256sum '2402d2029032ebd238a2046221e67f6ef0da78c5a8ce8cd4f8b9c62e4d6451d1'
+  pkg.version '2.4.0'
+  pkg.sha256sum '7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe'
   pkg.build_requires 'rubygem-faraday'
   ### End automated maintenance section ###
 

--- a/configs/components/rubygem-faraday.rb
+++ b/configs/components/rubygem-faraday.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-faraday' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '2.14.0'
-  pkg.sha256sum '8699cfe5d97e55268f2596f9a9d5a43736808a943714e3d9a53e6110593941cd'
+  pkg.version '2.14.1'
+  pkg.sha256sum 'a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c'
   pkg.build_requires 'rubygem-faraday-net_http'
   ### End automated maintenance section ###
 

--- a/configs/components/rubygem-ffi.rb
+++ b/configs/components/rubygem-ffi.rb
@@ -7,8 +7,8 @@
 #####
 component 'rubygem-ffi' do |pkg, settings, platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.17.2'
-  pkg.sha256sum '297235842e5947cc3036ebe64077584bff583cd7a4e94e9a02fdec399ef46da6'
+  pkg.version '1.17.3'
+  pkg.sha256sum '0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c'
   ### End automated maintenance section ###
 
   # Prior to ruby 3.2, both ruby and the ffi gem vendored a version of libffi.

--- a/configs/components/rubygem-http_parser.rb.rb
+++ b/configs/components/rubygem-http_parser.rb.rb
@@ -4,8 +4,8 @@
 #####
 component 'rubygem-http_parser.rb' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '0.8.0'
-  pkg.sha256sum '5a0932f1fa82ce08a8516a2685d5a86031c000560f89946913c555a0697544be'
+  pkg.version '0.8.1'
+  pkg.sha256sum '9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-net-http-persistent.rb
+++ b/configs/components/rubygem-net-http-persistent.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-net-http-persistent' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '4.0.6'
-  pkg.sha256sum '2abb3a04438edf6cb9e0e7e505969605f709eda3e3c5211beadd621a2c84dd5d'
+  pkg.version '4.0.8'
+  pkg.sha256sum 'ef3de8319d691537b329053fae3a33195f8b070bbbfae8bf1a58c796081960e6'
   pkg.build_requires 'rubygem-connection_pool'
   ### End automated maintenance section ###
 

--- a/configs/components/rubygem-net-http.rb
+++ b/configs/components/rubygem-net-http.rb
@@ -4,8 +4,8 @@
 #####
 component 'rubygem-net-http' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '0.8.0'
-  pkg.sha256sum 'df42c47ce9f9e95ad32a317c97c12f945bc1af365288837ea4ff259876ecb46d'
+  pkg.version '0.9.1'
+  pkg.sha256sum '25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-openfact.rb
+++ b/configs/components/rubygem-openfact.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-openfact' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '5.2.1'
-  pkg.sha256sum '766543bc3ccb1ba5646aaef38e88ced5438c13bb0d72e09d2dd6f9a07fabda0b'
+  pkg.version '5.3.0'
+  pkg.sha256sum 'bcc9a337fac2ebfc63cc45413b46915f073fea7fe1191025f06ada9ba662f1da'
   pkg.build_requires 'rubygem-base64'
   pkg.build_requires 'rubygem-hocon'
   pkg.build_requires 'rubygem-thor'

--- a/configs/components/rubygem-public_suffix.rb
+++ b/configs/components/rubygem-public_suffix.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-public_suffix' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '7.0.0'
-  pkg.sha256sum 'f7090b5beb0e56f9f10d79eed4d5fbe551b3b425da65877e075dad47a6a1b095'
+  pkg.version '7.0.2'
+  pkg.sha256sum '9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-thor.rb
+++ b/configs/components/rubygem-thor.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-thor' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.4.0'
-  pkg.sha256sum '8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d'
+  pkg.version '1.5.0'
+  pkg.sha256sum 'e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-unicode-emoji.rb
+++ b/configs/components/rubygem-unicode-emoji.rb
@@ -4,8 +4,8 @@
 #####
 component 'rubygem-unicode-emoji' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '4.1.0'
-  pkg.sha256sum '4997d2d5df1ed4252f4830a9b6e86f932e2013fbff2182a9ce9ccabda4f325a5'
+  pkg.version '4.2.0'
+  pkg.sha256sum '519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')


### PR DESCRIPTION
Component updates:
- rubygem-aws-partitions: version 1.1194.0 -> 1.1213.0
- rubygem-aws-sdk-core: version 3.239.2 -> 3.242.0
- rubygem-aws-sdk-ec2: version 1.585.0 -> 1.597.0
- rubygem-aws-sdk-ec2: version 1.593.0 -> 1.597.0
- rubygem-faraday-multipart: version 1.1.1 -> 1.2.0
- rubygem-faraday-retry: version 2.3.2 -> 2.4.0
- rubygem-faraday: version 2.14.0 -> 2.14.1
- rubygem-ffi: version 1.17.2 -> 1.17.3
- rubygem-http_parser.rb: version 0.8.0 -> 0.8.1
- rubygem-net-http-persistent: version 4.0.6 -> 4.0.8
- rubygem-net-http: version 0.8.0 -> 0.9.1
- rubygem-openfact: version 5.2.1 -> 5.3.0
- rubygem-public_suffix: version 7.0.0 -> 7.0.2
- rubygem-thor: version 1.4.0 -> 1.5.0
- rubygem-unicode-emoji: version 4.1.0 -> 4.2.0
