### PR TITLE
SLES 16: Add systemtap-dtrace

### DIFF
--- a/configs/platforms/sles-16-x86_64.rb
+++ b/configs/platforms/sles-16-x86_64.rb
@@ -7,6 +7,7 @@ platform 'sles-16-x86_64' do |plat|
     readline-devel
     zlib-devel
     systemtap-sdt-devel
+    systemtap-dtrace
   ]
   plat.provision_with("zypper -n install -y #{packages.join(' ')}")
 end


### PR DESCRIPTION
Required to compile Ruby with dtrace support