### PR TITLE
Add SLES 16 workaround for dtrace

### DIFF
--- a/configs/components/ruby-3.2.rb
+++ b/configs/components/ruby-3.2.rb
@@ -82,7 +82,7 @@ component 'ruby-3.2' do |pkg, settings, platform|
 
   special_flags = " --prefix=#{ruby_dir} --with-opt-dir=#{settings[:prefix]} "
 
-  if (platform.is_debian? && platform.os_version.to_i >= 13) || (platform.is_ubuntu? && platform.os_version =~ /25.04/)
+  if (platform.is_debian? && platform.os_version.to_i >= 13) || (platform.is_ubuntu? && platform.os_version =~ /25.04/ || platform.is_sles? && platform.os_version.to_i >= 16)
     # A problem with --enable-dtrace, which I suspect may be because of GCC on the Trixie image.
     # Check if this is still needed next time we bump Ruby and/or bump the Debian 13
     # container to the release version.


### PR DESCRIPTION
It fails with:

```
checking whether dtrace USDT is available... no
configure: error: --enable-dtrace, however, USDT is not available
make: *** [Makefile:349: ruby-3.2-configure] Error 1
```

The error occurs on our Ubuntu 24.04 runners.