### PR TITLE
Update rubygem-aws-sdk-ec2 & rubygem-openfact

### DIFF
--- a/configs/components/rubygem-aws-sdk-ec2.rb
+++ b/configs/components/rubygem-aws-sdk-ec2.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-aws-sdk-ec2' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.597.0'
-  pkg.sha256sum 'b4da34246a2721040d00e086a0d2cf0abb4ac0666f692a425eaeae32fac0de02'
+  pkg.version '1.601.0'
+  pkg.sha256sum '5ab7f78ac7017076e123d4287a13b814d7cafb130874eeb3a4e25d0cc0935d62'
   pkg.build_requires 'rubygem-aws-sdk-core'
   pkg.build_requires 'rubygem-aws-sigv4'
   ### End automated maintenance section ###

--- a/configs/components/rubygem-openfact.rb
+++ b/configs/components/rubygem-openfact.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-openfact' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '5.3.0'
-  pkg.sha256sum 'bcc9a337fac2ebfc63cc45413b46915f073fea7fe1191025f06ada9ba662f1da'
+  pkg.version '5.4.0'
+  pkg.sha256sum '9fac640c1124289a8a62fff51a793c9367cddd352a50a6d11fdff875e1b7ee21'
   pkg.build_requires 'rubygem-base64'
   pkg.build_requires 'rubygem-hocon'
   pkg.build_requires 'rubygem-thor'


### PR DESCRIPTION
Component updates:
- rubygem-aws-sdk-ec2: version 1.597.0 -> 1.601.0
- rubygem-openfact: version 5.3.0 -> 5.4.0