### PR TITLE
Update rubygem components and add signoff to update_gems task

### DIFF
--- a/configs/components/rubygem-aws-partitions.rb
+++ b/configs/components/rubygem-aws-partitions.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-aws-partitions' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.1237.0'
-  pkg.sha256sum '9b82f529b69ad83a8e4c5e123038924ed5e8f59bd6064a293ef20efc63364841'
+  pkg.version '1.1238.0'
+  pkg.sha256sum 'fa3d1bdea6d7e7619e8cee22ebce8a569d2119296d3ec8c5f9b9b7c81fb0602c'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-hiera-eyaml.rb
+++ b/configs/components/rubygem-hiera-eyaml.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-hiera-eyaml' do |pkg, settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '5.0.0'
-  pkg.sha256sum 'efdbc2d6d48897fc288047a391403b15c00cdf43de6765903997d4b65ae48895'
+  pkg.version '5.0.1'
+  pkg.sha256sum 'b463fc9aa8f310659251cc7efd8c5db2e0fa893c4bc5b97e07276cb597cb93e6'
   pkg.build_requires 'rubygem-base64'
   pkg.build_requires 'rubygem-highline'
   pkg.build_requires 'rubygem-optimist'

--- a/configs/components/rubygem-multi_json.rb
+++ b/configs/components/rubygem-multi_json.rb
@@ -5,8 +5,9 @@
 #####
 component 'rubygem-multi_json' do |pkg, settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.19.1'
-  pkg.sha256sum '7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7'
+  pkg.version '1.20.1'
+  pkg.sha256sum '2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d'
+  pkg.build_requires 'rubygem-concurrent-ruby'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/configs/components/rubygem-openvox.rb
+++ b/configs/components/rubygem-openvox.rb
@@ -7,8 +7,8 @@
 #####
 component 'rubygem-openvox' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '8.25.0'
-  pkg.sha256sum 'b0dbbe4581f2fc316959a78da5b4dde2d2cea849a142567ef9e214ffc811a526'
+  pkg.version '8.26.0'
+  pkg.sha256sum '9521f56fee57d0f70675bda180bbfd4b36b86ce5f940fc2390a397323e1f747e'
   pkg.build_requires 'rubygem-base64'
   pkg.build_requires 'rubygem-concurrent-ruby'
   pkg.build_requires 'rubygem-deep_merge'

--- a/configs/components/rubygem-yard.rb
+++ b/configs/components/rubygem-yard.rb
@@ -5,8 +5,8 @@
 #####
 component 'rubygem-yard' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '0.9.39'
-  pkg.sha256sum '0bbbcd87ffd132824c3f89bbd39deef1ffb3877259090849bd49e48daeaf7b56'
+  pkg.version '0.9.41'
+  pkg.sha256sum '2fad2f362bceb63101f37aeb81d35cfc50b4ae1c11cf22f54b8d46626877a89f'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')

--- a/tasks/update_gems.rake
+++ b/tasks/update_gems.rake
@@ -445,7 +445,7 @@ def git_commit(message)
   warn "git diff --cached failed:\n#{err}\n#{out}" unless ok
   return if !ok || out.strip.empty?
 
-  args = ['git', '-C', REPO_ROOT, 'commit', '-m', 'Update rubygem components']
+  args = ['git', '-C', REPO_ROOT, 'commit', '-s', '-m', 'Update rubygem components']
   args += ['-m', message] unless message.empty?
 
   _, err, ok = Open3.capture3(*args)


### PR DESCRIPTION
Component updates:
- rubygem-aws-partitions: version 1.1237.0 -> 1.1238.0
- rubygem-hiera-eyaml: version 5.0.0 -> 5.0.1
- rubygem-multi_json: version 1.19.1 -> 1.20.1, added deps: rubygem-concurrent-ruby
- rubygem-openvox: version 8.25.0 -> 8.26.0
- rubygem-yard: version 0.9.39 -> 0.9.41

Adds the -s flag to git commit in the update_gems task.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
