### PR TITLE
multi_json: Downgrade 1.20.1->1.19.1

### DIFF
--- a/configs/components/rubygem-multi_json.rb
+++ b/configs/components/rubygem-multi_json.rb
@@ -5,9 +5,11 @@
 #####
 component 'rubygem-multi_json' do |pkg, settings, _platform|
   ### Maintained by update_gems automation ###
-  pkg.version '1.20.1'
-  pkg.sha256sum '2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d'
-  pkg.build_requires 'rubygem-concurrent-ruby'
+  # PINNED
+  # 1.20.0 introduced a breaking change :melting_face:
+  # https://github.com/sferik/multi_json/commit/ca2c747570335f8d3b6b0904aae6ace41329aedd
+  pkg.version '1.19.1'
+  pkg.sha256sum '7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7'
   ### End automated maintenance section ###
 
   instance_eval File.read('configs/components/_base-rubygem.rb')


### PR DESCRIPTION
1.20.0 introduced a breaking change :melting_face: https://github.com/sferik/multi_json/commit/ca2c747570335f8d3b6b0904aae6ace41329aedd

This was initially upgraded in 75960a166fe1eb203e2c88c463ce65a9901963ed

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
