### PR TITLE
Changes for 8.x branching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,11 @@ on:
         required: true
       project_name:
         description: 'The vanagon project to build'
-        required: false
+        type: choice
+        options:
+          - agent-runtime-main
+          - agent-runtime-8.x
+          - openbolt-runtime
         default: 'agent-runtime-main'
       platform_list:
         description: 'A comma-separated list of platforms to build for. Do not include spaces. If not provided, will use the default list of platform supported by OpenVox.'
@@ -44,6 +48,7 @@ jobs:
       platform_list: ${{ inputs.platform_list }}
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
+      branch: 'main'
     secrets: inherit
   build_dev:
     if: ${{ github.event.inputs.use_dev == 'true' }}
@@ -54,4 +59,5 @@ jobs:
       platform_list: ${{ inputs.platform_list }}
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
+      branch: 'main'
     secrets: inherit

--- a/.github/workflows/runtime_tests.yml
+++ b/.github/workflows/runtime_tests.yml
@@ -60,9 +60,12 @@ jobs:
   build:
     needs: vanagon_inspect
     name: build puppet-runtime for Linux
+    strategy:
+      matrix:
+        project_name: ['agent-runtime-main', 'agent-runtime-8.x', 'openbolt-runtime']
     uses: 'openvoxproject/shared-actions/.github/workflows/build_vanagon.yml@main'
     with:
-      project_name: 'agent-runtime-main'
+      project_name: ${{ matrix.project_name }}
       # when we add new OSes here, we also need to add them in openvoxproject/shared-actions
       # TODO: Split OS list into Linux and non-linux, then run Linux on all PRs
       platform_list: amazon-2-aarch64,amazon-2-x86_64,amazon-2023-aarch64,amazon-2023-x86_64,debian-11-aarch64,debian-11-amd64,debian-12-aarch64,debian-12-amd64,debian-13-aarch64,debian-13-amd64,debian-13-armhf,el-8-aarch64,el-8-x86_64,el-9-aarch64,el-9-x86_64,el-10-x86_64,el-10-aarch64,fedora-42-x86_64,fedora-42-aarch64,fedora-43-x86_64,fedora-43-aarch64,sles-15-x86_64,ubuntu-22.04-aarch64,ubuntu-22.04-amd64,ubuntu-24.04-aarch64,ubuntu-24.04-amd64,ubuntu-24.04-armhf,ubuntu-25.04-amd64,ubuntu-25.04-aarch64,ubuntu-25.04-armhf,ubuntu-26.04-aarch64,ubuntu-26.04-amd64,ubuntu-26.04-armhf

--- a/configs/projects/agent-runtime-8.x.rb
+++ b/configs/projects/agent-runtime-8.x.rb
@@ -1,0 +1,112 @@
+project 'agent-runtime-8.x' do |proj|
+  # Set preferred component versions if they differ from defaults:
+  proj.setting :ruby_version, '3.2' # Leave the .Z out for Ruby 3.2
+  proj.setting :rubygem_highline_version, '3.0.1'
+
+  ########
+  # Load shared agent settings
+  ########
+
+  instance_eval File.read(File.join(File.dirname(__FILE__), '_shared-agent-settings.rb'))
+
+  ########
+  # Settings specific to this branch
+  ########
+
+  # Directory for gems shared by puppet and puppetserver
+  proj.setting(:puppet_gem_vendor_dir, File.join(proj.libdir, 'ruby', 'vendor_gems'))
+
+  # Ruby 2.7 loads openssl on installation. Because pl-ruby was not
+  # built with openssl support, we switch to compile with system
+  # rubies.
+  # Solaris 11 seems to work with pl-ruby, and 10 is handled in _shared-agent-settings.rb.
+  proj.setting(:host_ruby, '/usr/bin/ruby') if platform.is_cross_compiled_linux?
+
+  # Ruby 2.6 (RubyGems 3.0.1) removed the --ri and --rdoc
+  # options. Switch to using --no-document which is available starting
+  # with RubyGems 2.0.0preview2. This should also cover cross-compiled
+  # platforms that use older rubies.
+  proj.setting(:gem_install, "#{proj.host_gem} install --no-document --local")
+
+  ########
+  # Components
+  # Use full blocks here, rather than single line logic so that
+  # automation can insert components as needed.
+  ########
+
+  # rubocop:disable Style/IfUnlessModifier
+
+  proj.component 'runtime-agent'
+  proj.component 'libffi'
+  proj.component 'libyaml'
+  proj.component "openssl-#{proj.openssl_version}"
+
+  proj.component 'curl'
+  proj.component 'puppet-ca-bundle'
+  proj.component "ruby-#{proj.ruby_version}"
+
+  proj.component 'rubygem-base64'
+  proj.component 'rubygem-concurrent-ruby'
+  proj.component 'rubygem-deep_merge'
+  proj.component 'rubygem-erubi'
+  proj.component 'rubygem-fast_gettext'
+  proj.component 'rubygem-ffi'
+  proj.component 'rubygem-gettext'
+  proj.component 'rubygem-hiera-eyaml'
+  proj.component 'rubygem-highline'
+  proj.component 'rubygem-hocon'
+  proj.component 'rubygem-locale'
+  proj.component 'rubygem-multi_json' # TODO: obsolete for openvox 9 - https://github.com/OpenVoxProject/openvox/pull/293
+  proj.component 'rubygem-net-ssh'
+  proj.component 'rubygem-optimist'
+  proj.component 'rubygem-semantic_puppet'
+  proj.component 'rubygem-scanf'
+  proj.component 'rubygem-text'
+  proj.component 'rubygem-thor'
+
+  # We add rexml explicitly in here because even though ruby 3 ships with rexml as its default gem, the version
+  # of rexml it ships with can contain CVEs. So, we add it here to update to a higher version free from the CVEs.
+  proj.component 'rubygem-rexml'
+
+  unless platform.is_windows?
+    proj.component 'augeas'
+    proj.component 'ruby-augeas'
+    proj.component 'libxml2'
+    proj.component 'rubygem-sys-filesystem'
+  end
+
+  if platform.is_macos?
+    proj.component 'readline'
+    proj.component 'rubygem-CFPropertyList'
+  end
+
+  unless platform.is_aix? || platform.is_windows?
+    proj.component 'ruby-shadow'
+  end
+
+  # We only build ruby-selinux for EL, Fedora, Debian and Ubuntu (amd64/i386)
+  if platform.is_el? || platform.is_fedora? || platform.is_debian? || (platform.is_ubuntu? && platform.architecture !~ /ppc64el$/)
+    proj.component 'ruby-selinux'
+  end
+
+  # libedit is used instead of readline on these platforms
+  if platform.is_solaris?
+    proj.component 'libedit'
+  end
+
+  if platform.is_cross_compiled?
+    proj.component 'pl-ruby-patch'
+  end
+
+  if platform.is_windows? || platform.is_solaris? || platform.is_aix?
+    proj.component 'rubygem-minitar'
+  end
+
+  if platform.is_linux?
+    proj.component 'virt-what'
+    proj.component 'dmidecode' unless platform.architecture =~ /ppc64/
+    # DBus exists outside of Linux, but it's the most common platform to find it on
+    proj.component 'rubygem-ruby-dbus'
+  end
+  # rubocop:enable Style/IfUnlessModifier
+end


### PR DESCRIPTION
Add agent-runtime-8.x that is a copy of agent-runtime-main for now. Additionally, add branch selection and project choice to the workflow, both for simplicity and because we need to pass the branch into the shared build_vanagon so it can look up the right default platforms list. Finally, have CI tests try building all 3 projects.