### PR TITLE
net-imap: Update 0.3.9->0.4.24

### DIFF
--- a/configs/components/ruby-3.2.rb
+++ b/configs/components/ruby-3.2.rb
@@ -45,6 +45,26 @@ component 'ruby-3.2' do |pkg, settings, platform|
   # Upgrade erb 4.0.2 -> 4.0.3.1, fixes CVE-2026-41316
   pkg.apply_patch "#{base}/upgrade-erb-4.0.3.1.patch"
 
+  # Upgrade net-imap 0.3.9 -> 0.4.24, fixes CVE-2026-42246, other CVEs, and build issues.
+  pkg.add_source(
+    'https://rubygems.org/downloads/net-imap-0.4.24.gem',
+    {
+      sum: '88289db8fd3f08aa8c661137810118e58fe309829e815e2ea8f3650662a6501b',
+      sum_type: 'sha256'
+    }
+  )
+  pkg.configure do
+    [
+      'cp ../net-imap-0.4.24.gem gems/',
+      "sed -i.bak 's/^net-imap.*/net-imap 0.4.24 https:\\/\\/github.com\\/ruby\\/net-imap/' gems/bundled_gems",
+      # This next bit can be done via "make extract-gems", but that requires us
+      # to have a "baseruby" installed.
+      'tar xf gems/net-imap-0.4.24.gem',
+      'mkdir .bundle/gems/net-imap-0.4.24',
+      'tar -C .bundle/gems/net-imap-0.4.24 -xzf data.tar.gz'
+    ]
+  end
+
   ####################
   # ENVIRONMENT, FLAGS
   ####################


### PR DESCRIPTION
This commit upgrades the bundled net-imap gem in Ruby 3.2.11 from the original version of 0.3.9 to 04.24. This release contains a fix for the following high-severity issue with STARTTLS:

  - https://github.com/ruby/net-imap/security/advisories/GHSA-vcgp-9326-pqcp

There will be no further upstream releases to Ruby 3.2, thus we have to upgrade this gem ourselves. The 0.4.0 release has a few breaking changes, however there are several issues with the 0.3.10 version of `net-imap`:

  - It will be the last release to `net-imap` 0.3.x

  - The 0.3.x releases will not install in containerized build environments where the default locale is set to `POSIX` (Debian). This was resloved in the 0.4.3 release by: https://github.com/ruby/net-imap/pull/210

  - The 0.4.24 release contains fixes for additional medium-to-low severity issues:

      * https://github.com/ruby/net-imap/security/advisories/GHSA-hm49-wcqc-g2xg
      * https://github.com/ruby/net-imap/security/advisories/GHSA-q2mw-fvj9-vvcw
      * https://github.com/ruby/net-imap/security/advisories/GHSA-87pf-fpwv-p7m7
      * https://github.com/ruby/net-imap/security/advisories/GHSA-75xq-5h9v-w6px

CVE-2026-42246
CVE-2026-42257
CVE-2026-42256
CVE-2026-42258
CVE-2026-42245

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
