### PR TITLE
CI: Dont skip PE projects & only build agent-runtime-main

### DIFF
--- a/.github/workflows/runtime_tests.yml
+++ b/.github/workflows/runtime_tests.yml
@@ -56,7 +56,9 @@ jobs:
     name: build puppet-runtime for Linux
     strategy:
       matrix:
-        project_name: ['agent-runtime-main', 'agent-runtime-8.x', 'openbolt-runtime']
+        # The matrix causes duplicate files, needs to be fixed in openvoxproject/shared-actions
+        #project_name: ['agent-runtime-main', 'agent-runtime-8.x', 'openbolt-runtime']
+        project_name: ['agent-runtime-main',]
     uses: 'openvoxproject/shared-actions/.github/workflows/build_vanagon.yml@main'
     with:
       project_name: ${{ matrix.project_name }}

--- a/.github/workflows/runtime_tests.yml
+++ b/.github/workflows/runtime_tests.yml
@@ -35,10 +35,6 @@ jobs:
           for projfile in configs/projects/[a-z]*.rb; do
             for plat in $(bundle exec vanagon list --platforms | tail -n +2); do
               proj=$(basename -s .rb "$projfile")
-              if [[ "$proj" =~ ^pe- && "$plat" =~ ^(windows|osx) ]]; then
-                echo Skipping ${proj} on ${plat}, PE projects don\'t support Windows or macOS
-                continue
-              fi
               echo Inspecting ${proj} on ${plat}
               output=$(bundle exec vanagon inspect "$proj" "$plat")
               if [ $? -ne 0 ]; then


### PR DESCRIPTION
CI config had an if condition to skip validating PE projects. This is a leftover from Perforce. At OpenVox, we don't have PE projects, so we can just remove it. This makes it a tiny bit more readable.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
