### PR TITLE
update_component_info: Dont ignore armhf & redhatfips

### DIFF
--- a/tasks/update_component_info.rake
+++ b/tasks/update_component_info.rake
@@ -1,7 +1,7 @@
 require 'json'
 
 FIRST_TAG = '202501080'.freeze # First tag to include when regenerating
-IGNORED_PLATFORMS = %w[aix solaris redhatfips windowsfips el-6 osx sles-11 windows-2012r2 ppc64le i386].freeze
+IGNORED_PLATFORMS = %w[aix solaris windowsfips el-6 osx sles-11 windows-2012r2 ppc64le i386].freeze
 INCLUDED_PROJECTS = %w[agent-runtime openbolt-runtime].freeze
 
 def platforms

--- a/tasks/update_component_info.rake
+++ b/tasks/update_component_info.rake
@@ -1,7 +1,7 @@
 require 'json'
 
 FIRST_TAG = '202501080'.freeze # First tag to include when regenerating
-IGNORED_PLATFORMS = %w[aix solaris redhatfips windowsfips el-6 osx sles-11 windows-2012r2 ppc64le armhf i386].freeze
+IGNORED_PLATFORMS = %w[aix solaris redhatfips windowsfips el-6 osx sles-11 windows-2012r2 ppc64le i386].freeze
 INCLUDED_PROJECTS = %w[agent-runtime openbolt-runtime].freeze
 
 def platforms


### PR DESCRIPTION
We have a list of platforms we ignore for generating our json SBOM files. Since we now have a few armhf builds (32bit ARM), we shouldn't ignore this architecture anymore.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
