### PR TITLE
vanagon: be more verbose

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -19,7 +19,7 @@ namespace :vox do
     end
 
     engine = platform =~ /^(macos|windows)-/ ? 'local' : 'docker'
-    cmd = "bundle exec vanagon build #{project} #{platform} --engine #{engine}"
+    cmd = "bundle exec vanagon build #{project} #{platform} --engine #{engine} --verbose"
 
     FileUtils.rm_rf('C:/ProgramFiles64Folder/') if platform =~ /^windows-/
 


### PR DESCRIPTION
the `build` command is deprecated:

https://github.com/OpenVoxProject/vanagon/blob/main/bin/build

also in case of issues, it is very helpful to output a trace.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
