### PR TITLE
Use vanagon build

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -19,7 +19,7 @@ namespace :vox do
     end
 
     engine = platform =~ /^(macos|windows)-/ ? 'local' : 'docker'
-    cmd = "bundle exec build #{project} #{platform} --engine #{engine}"
+    cmd = "bundle exec vanagon build #{project} #{platform} --engine #{engine}"
 
     FileUtils.rm_rf('C:/ProgramFiles64Folder/') if platform =~ /^windows-/
 


### PR DESCRIPTION
The standalone build command is depricated, so this gets rid of a pesky warning.