### PR TITLE
Build workflow fixups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Tag to build'
+        description: 'Tag to build for a release, or branch to build for a pre-release'
         required: true
       project_name:
         description: 'The vanagon project to build'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,13 @@ on:
         required: false
         type: boolean
         default: false
+      branch:
+        description: 'The release branch to build from.'
+        type: choice
+        options:
+          - main
+          - '8.x'
+        default: 'main'
 
 jobs:
   build:
@@ -48,7 +55,7 @@ jobs:
       platform_list: ${{ inputs.platform_list }}
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
-      branch: 'main'
+      branch: ${{ inputs.branch }}
     secrets: inherit
   build_dev:
     if: ${{ github.event.inputs.use_dev == 'true' }}
@@ -59,5 +66,5 @@ jobs:
       platform_list: ${{ inputs.platform_list }}
       vanagon_branch: ${{ inputs.vanagon_branch }}
       upload_to_s3: ${{ inputs.upload_to_s3 }}
-      branch: 'main'
+      branch: ${{ inputs.branch }}
     secrets: inherit


### PR DESCRIPTION
### Short description

This patchset ports OpenVoxProject/openvox#425 over to `puppet-runtime`. The change adds a drop-down that allows selection of which platform set from `platforms.json` in OpenVoxProject/shared-actions should be used by the build.

This enables building `agent-runtime-8.x` against the 8.x platform list instead of the OpenVox 9 list.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
