### PR TITLE
Build Ruby 4 under MSYS2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,9 @@ gem 'rake', '~> 13.0'
 gem 'rubocop', '~> 1.86'
 gem 'rubocop-rake', '~> 0.7'
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || 'https://github.com/openvoxproject/vanagon#main')
-# Need to update the openssl gem on MacOS to avoid SSL errors. Doesn't hurt to have the newest
-# for all platforms.
+# Need to update the openssl gem on MacOS to avoid SSL errors.
 # https://www.rubyonmac.dev/certificate-verify-failed-unable-to-get-certificate-crl-openssl-ssl-sslerror
-gem 'openssl' unless `uname -o`.chomp == 'Cygwin'
+gem 'openssl', '~> 3' if RUBY_PLATFORM =~ /darwin/
 
 gem 'octokit', '< 11'
 

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -19,7 +19,11 @@ ruby_bindir ||= settings[:ruby_bindir]
 if platform.is_windows?
   pkg.environment 'PATH',
                   "$(shell cygpath -u #{settings[:gcc_bindir]}):$(shell cygpath -u #{settings[:tools_root]}/bin):$(shell cygpath -u #{settings[:tools_root]}/include):$(shell cygpath -u #{settings[:bindir]}):$(shell cygpath -u #{ruby_bindir}):$(shell cygpath -u #{settings[:includedir]}):$(PATH)"
-  pkg.environment 'CYGWIN', settings[:cygwin]
+  if settings[:cygwin]
+    pkg.environment 'CYGWIN', settings[:cygwin]
+  elsif settings[:msys]
+    pkg.environment 'MSYS', settings[:msys]
+  end
   pkg.environment 'LDFLAGS', settings[:ldflags]
   optflags = "#{settings[:cflags]} -O3"
   pkg.environment 'optflags', optflags

--- a/configs/components/_base-ruby.rb
+++ b/configs/components/_base-ruby.rb
@@ -25,9 +25,7 @@ if platform.is_windows?
     pkg.environment 'MSYS', settings[:msys]
   end
   pkg.environment 'LDFLAGS', settings[:ldflags]
-  optflags = "#{settings[:cflags]} -O3"
-  pkg.environment 'optflags', optflags
-  pkg.environment 'CFLAGS', optflags
+  pkg.environment 'CFLAGS', settings[:cflags]
 elsif platform.is_macos?
   pkg.environment 'optflags', settings[:cflags]
   pkg.environment 'CFLAGS', settings[:cflags]

--- a/configs/components/ruby-4.0.rb
+++ b/configs/components/ruby-4.0.rb
@@ -54,7 +54,7 @@ component 'ruby-4.0' do |pkg, settings, platform|
     pkg.environment 'MACOSX_DEPLOYMENT_TARGET', settings[:deployment_target]
     pkg.environment 'PATH', '$(PATH):/opt/homebrew/bin:/usr/local/bin'
   elsif platform.is_windows?
-    optflags = "#{cflags} -O3"
+    optflags = "#{cflags} -O2"
     pkg.environment 'optflags', optflags
     pkg.environment 'CFLAGS', optflags
     pkg.environment 'MAKE', 'make'
@@ -81,23 +81,12 @@ component 'ruby-4.0' do |pkg, settings, platform|
   # want to use/maintain pl-ruby if we don't have to. Instead set baseruby to
   # "no" which will force ruby to build and use miniruby.
   special_flags += ' --with-baseruby=no '
-
-  if platform.is_windows?
-    # ruby's configure script guesses the build host is `cygwin`, because we're using
-    # cygwin opensshd & bash. So mkmf will convert compiler paths, e.g. -IC:/... to
-    # cygwin paths, -I/cygdrive/c/..., which confuses mingw-w64. So specify the build
-    # target explicitly.
-    special_flags += " CPPFLAGS='-DFD_SETSIZE=2048' debugflags=-g "
-
-    special_flags += ' --build x86_64-w64-mingw32 '
-  elsif platform.is_macos?
-    special_flags += " --with-openssl-dir=#{settings[:prefix]} "
-  end
+  special_flags += " --with-openssl-dir=#{settings[:prefix]} " if platform.is_macos?
 
   without_dtrace = [
     'macos-all-arm64',
     'macos-all-x86_64',
-    'windows-all-x64'
+    'windows-msys2-x64'
   ]
 
   # sometimes dtrace will be enabled at compile time if the dtrace binary is present
@@ -136,7 +125,7 @@ component 'ruby-4.0' do |pkg, settings, platform|
     'ubuntu-25.04-amd64',
     'ubuntu-25.04-armhf',
     'ubuntu-26.04-armhf',
-    'windows-all-x64'
+    'windows-msys2-x64'
   ]
   if platforms_without_rust.include? platform.name
     configure_flags = ''
@@ -180,7 +169,7 @@ component 'ruby-4.0' do |pkg, settings, platform|
     'aarch64-redhat-linux' => 'aarch64-linux',
     'arm-linux-gnueabihf' => 'arm-linux-eabihf',
     'arm-linux-gnueabi' => 'arm-linux-eabi',
-    'x86_64-w64-mingw32' => 'x64-mingw32'
+    'x86_64-w64-mingw32' => 'x64-mingw32-ucrt'
   }
   rbconfig_topdir = if target_doubles.key?(settings[:platform_triple])
                       File.join(ruby_dir, 'lib', 'ruby', '4.0.0', target_doubles[settings[:platform_triple]])
@@ -195,11 +184,7 @@ component 'ruby-4.0' do |pkg, settings, platform|
   # then the CC override allows us to build ffi_c.so for ARM as well. The
   # "host" ruby is configured in _shared-agent-settings
   rbconfig_changes = {}
-  if platform.is_macos?
-    rbconfig_changes['CC'] = "#{settings[:cc]} #{cflags}"
-  elsif platform.is_windows?
-    rbconfig_changes['CC'] = 'x86_64-w64-mingw32-gcc'
-  end
+  rbconfig_changes['CC'] = "#{settings[:cc]} #{cflags}" if platform.is_macos?
 
   pkg.add_source('file://resources/files/ruby_vendor_gems/operating_system.rb')
   defaults_dir = File.join(settings[:libdir], 'ruby/4.0.0/rubygems/defaults')

--- a/configs/components/ruby-4.0.rb
+++ b/configs/components/ruby-4.0.rb
@@ -53,11 +53,6 @@ component 'ruby-4.0' do |pkg, settings, platform|
     pkg.environment 'CXX', settings[:cxx]
     pkg.environment 'MACOSX_DEPLOYMENT_TARGET', settings[:deployment_target]
     pkg.environment 'PATH', '$(PATH):/opt/homebrew/bin:/usr/local/bin'
-  elsif platform.is_windows?
-    optflags = "#{cflags} -O2"
-    pkg.environment 'optflags', optflags
-    pkg.environment 'CFLAGS', optflags
-    pkg.environment 'MAKE', 'make'
   else
     pkg.environment 'optflags', '-O2'
   end

--- a/configs/components/ruby-4.0.rb
+++ b/configs/components/ruby-4.0.rb
@@ -160,9 +160,6 @@ component 'ruby-4.0' do |pkg, settings, platform|
         "mv #{ruby_bindir}/#{name}.cmd #{ruby_bindir}/#{name}.bat"
       end
     end
-
-    # Required when using `stack-protection-strong` and older versions of mingw-w64-gcc
-    pkg.install_file File.join(settings[:gcc_bindir], 'libssp-0.dll'), File.join(settings[:bindir], 'libssp-0.dll')
   end
 
   target_doubles = {

--- a/configs/components/rubygem-jwt.rb
+++ b/configs/components/rubygem-jwt.rb
@@ -4,6 +4,7 @@
 #   https://github.com/jwt/ruby-jwt/blob/v3.1.2/CHANGELOG.md
 # Notes:
 #   r10k pins this to < 3, so pinning to the latest 2.x version for now.
+#   https://github.com/puppetlabs/r10k/pull/1434
 #####
 component 'rubygem-jwt' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###

--- a/configs/components/runtime-agent.rb
+++ b/configs/components/runtime-agent.rb
@@ -4,21 +4,38 @@ component 'runtime-agent' do |pkg, settings, platform|
   pkg.add_source 'file://resources/files/runtime/runtime.sh'
 
   if platform.is_windows?
-    lib_type = platform.architecture == 'x64' ? 'seh' : 'sjlj'
-    pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll",
-                     "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:bindir]}/libstdc++-6.dll"
-    pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:bindir]}/libwinpthread-1.dll"
+    if settings[:cygwin]
+      lib_type = platform.architecture == 'x64' ? 'seh' : 'sjlj'
+      pkg.install_file "#{settings[:gcc_bindir]}/libgcc_s_#{lib_type}-1.dll",
+                       "#{settings[:bindir]}/libgcc_s_#{lib_type}-1.dll"
+      pkg.install_file "#{settings[:gcc_bindir]}/libstdc++-6.dll", "#{settings[:bindir]}/libstdc++-6.dll"
+      pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll", "#{settings[:bindir]}/libwinpthread-1.dll"
 
-    # Curl is dynamically linking against zlib, so we need to include this file until we
-    # update curl to statically link against zlib
-    pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:ruby_bindir]}/zlib1.dll"
+      # Curl is dynamically linking against zlib, so we need to include this file until we
+      # update curl to statically link against zlib
+      pkg.install_file "#{settings[:tools_root]}/bin/zlib1.dll", "#{settings[:ruby_bindir]}/zlib1.dll"
 
-    # gdbm and iconv are all runtime dependencies of ruby, and their libraries need
-    # to exist inside our vendored ruby
-    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll",
-                     "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
-    pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
+      # gdbm and iconv are all runtime dependencies of ruby, and their libraries need
+      # to exist inside our vendored ruby
+      pkg.install_file "#{settings[:tools_root]}/bin/libgdbm-4.dll", "#{settings[:ruby_bindir]}/libgdbm-4.dll"
+      pkg.install_file "#{settings[:tools_root]}/bin/libgdbm_compat-4.dll",
+                       "#{settings[:ruby_bindir]}/libgdbm_compat-4.dll"
+      pkg.install_file "#{settings[:tools_root]}/bin/libffi-6.dll", "#{settings[:ruby_bindir]}/libffi-6.dll"
+    elsif settings[:msys]
+      pkg.build_requires 'mingw-w64-ucrt-x86_64-gmp'
+      pkg.build_requires 'mingw-w64-ucrt-x86_64-libwinpthread'
+      pkg.build_requires 'mingw-w64-ucrt-x86_64-zlib'
+
+      # Matches what the ruby-lang.org builds copy into
+      #     C:\Ruby40-x64\ruby_builtin_dlls\
+      pkg.install_file "#{settings[:gcc_bindir]}/libgmp-10.dll",
+                       "#{settings[:bindir]}/libgmp-10.dll"
+      pkg.install_file "#{settings[:gcc_bindir]}/libwinpthread-1.dll",
+                       "#{settings[:bindir]}/libwinpthread-1.dll"
+
+      # Used by the zlib default gem.
+      pkg.install_file "#{settings[:gcc_bindir]}/zlib1.dll",
+                       "#{settings[:bindir]}/zlib1.dll"
+    end
   end
 end

--- a/configs/platforms/windows-msys2-x64.rb
+++ b/configs/platforms/windows-msys2-x64.rb
@@ -1,0 +1,5 @@
+platform 'windows-msys2-x64' do |plat|
+  plat.inherit_from_default
+
+  plat.package_type 'archive'
+end

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -119,9 +119,19 @@ proj.setting(:host, host)
 instance_eval File.read('configs/projects/_shared-compiler-settings.rb')
 
 if platform.is_windows?
-  proj.setting(:gcc_root, '/usr/x86_64-w64-mingw32/sys-root/mingw')
-  proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
-  proj.setting(:tools_root, '/usr/x86_64-w64-mingw32/sys-root/mingw')
+  if platform.name =~ /^windows-msys2/
+    # MSYS2 UCRT64: native compiler, libraries live under /ucrt64
+    proj.setting(:gcc_root, '/ucrt64')
+    proj.setting(:gcc_bindir, '/ucrt64/bin')
+    proj.setting(:tools_root, '/ucrt64')
+    proj.setting(:msys, 'winsymlinks:nativestrict')
+  else
+    # Cygwin + mingw-w64 cross-compiler
+    proj.setting(:gcc_root, '/usr/x86_64-w64-mingw32/sys-root/mingw')
+    proj.setting(:gcc_bindir, "#{proj.gcc_root}/bin")
+    proj.setting(:tools_root, '/usr/x86_64-w64-mingw32/sys-root/mingw')
+    proj.setting(:cygwin, 'nodosfilewarning winsymlinks:native')
+  end
   # If tools_root ever differs from gcc_root again, add it back here.
   proj.setting(:cppflags, "-I#{proj.gcc_root}/include -I#{proj.gcc_root}/include/readline -I#{proj.includedir}")
   proj.setting(:cflags, proj.cppflags)
@@ -129,8 +139,6 @@ if platform.is_windows?
   ldflags = "-L#{proj.tools_root}/lib -L#{proj.gcc_root}/lib -L#{proj.libdir} -Wl,--nxcompat"
   ldflags += ' -Wl,--dynamicbase' if platform.name !~ /windowsfips-/ || name != 'agent-runtime-7.x'
   proj.setting(:ldflags, ldflags)
-
-  proj.setting(:cygwin, 'nodosfilewarning winsymlinks:native')
 end
 
 if platform.is_macos?


### PR DESCRIPTION
### Short description

This commit updates the build logic for `agent-runtime-main` to use a new `windows-msys2-x64` platform to build the Ruby 4 runtime under MSYS2 + MINGW-w64-UCRT. The older Cygwin + MINGW build is retained for building `agent-runtime-8.x` against MSVCRT.

Switching to UCRT is required as upstream Ruby 3.1 migrated to using this C runtime and Ruby 4.0 no longer builds against the older MSVCRT. Besides fixing the build, using the same `x64-mingw-ucrt` architecture as upstream Ruby allows pre-compiled Rubygems, e.g. `nokogiri`, to be installed without requiring Windows nodes to have a C compiler and other devtools installed.

Massive credit to @sebastianrakel for the initial implementation and for determining how to make MSYS2 co-exist with the legacy Cygwin build.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)