### PR TITLE
OpenSSL June 2026 Security Releases

### DIFF
--- a/configs/components/openssl-3.0.json
+++ b/configs/components/openssl-3.0.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.20",
-  "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.20/openssl-3.0.20.tar.gz",
-  "sha256sum": "c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f"
+  "version": "3.0.21",
+  "url": "https://github.com/openssl/openssl/releases/download/openssl-3.0.21/openssl-3.0.21.tar.gz",
+  "sha256sum": "617e29af8e421f46649484a4937e48c685e47f46488167c982f88bc4ec1d522f"
 }

--- a/configs/components/openssl-3.5.json
+++ b/configs/components/openssl-3.5.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.5.6",
-  "url": "https://github.com/openssl/openssl/releases/download/openssl-3.5.6/openssl-3.5.6.tar.gz",
-  "sha256sum": "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736"
+  "version": "3.5.7",
+  "url": "https://github.com/openssl/openssl/releases/download/openssl-3.5.7/openssl-3.5.7.tar.gz",
+  "sha256sum": "a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8"
 }


### PR DESCRIPTION
### Short description

This changeset brings in the Jun 9th security releases of OpenSSL 3.0 and 3.5:

- 3.5.7: https://github.com/openssl/openssl/releases/tag/openssl-3.5.7
- 3.0.21: https://github.com/openssl/openssl/releases/tag/openssl-3.0.21

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
