### PR TITLE
net-imap: Update 0.4.24->0.6.4.1

### DIFF
--- a/configs/components/ruby-3.2.rb
+++ b/configs/components/ruby-3.2.rb
@@ -41,23 +41,24 @@ component 'ruby-3.2' do |pkg, settings, platform|
   # Upgrade erb 4.0.2 -> 4.0.3.1, fixes CVE-2026-41316
   pkg.apply_patch "#{base}/upgrade-erb-4.0.3.1.patch"
 
-  # Upgrade net-imap 0.3.9 -> 0.4.24, fixes CVE-2026-42246, other CVEs, and build issues.
+  # Upgrade net-imap 0.3.9 -> 0.6.4.1, fixes CVE-2026-42246, CVE-2026-47240,
+  # other CVEs, and build issues.
   pkg.add_source(
-    'https://rubygems.org/downloads/net-imap-0.4.24.gem',
+    'https://rubygems.org/downloads/net-imap-0.6.4.1.gem',
     {
-      sum: '88289db8fd3f08aa8c661137810118e58fe309829e815e2ea8f3650662a6501b',
+      sum: '29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d',
       sum_type: 'sha256'
     }
   )
   pkg.configure do
     [
-      'cp ../net-imap-0.4.24.gem gems/',
-      "sed -i.bak 's/^net-imap.*/net-imap 0.4.24 https:\\/\\/github.com\\/ruby\\/net-imap/' gems/bundled_gems",
+      'cp ../net-imap-0.6.4.1.gem gems/',
+      "sed -i.bak 's/^net-imap.*/net-imap 0.6.4.1 https:\\/\\/github.com\\/ruby\\/net-imap/' gems/bundled_gems",
       # This next bit can be done via "make extract-gems", but that requires us
       # to have a "baseruby" installed.
-      'tar xf gems/net-imap-0.4.24.gem',
-      'mkdir .bundle/gems/net-imap-0.4.24',
-      'tar -C .bundle/gems/net-imap-0.4.24 -xzf data.tar.gz'
+      'tar xf gems/net-imap-0.6.4.1.gem',
+      'mkdir .bundle/gems/net-imap-0.6.4.1',
+      'tar -C .bundle/gems/net-imap-0.6.4.1 -xzf data.tar.gz'
     ]
   end
 


### PR DESCRIPTION
### Short description

This commit upgrades the bundled net-imap gem in Ruby 3.2.11 from the previous patched version of 0.4.24 to 0.6.4.1. This release contains fixes for the following medium and low-severity security issues:

  - https://github.com/ruby/net-imap/security/advisories/GHSA-46q3-7gv7-qmgg
  - https://github.com/ruby/net-imap/security/advisories/GHSA-8p34-64r3-mwg8
  - https://github.com/ruby/net-imap/security/advisories/GHSA-c4fp-cxrr-mj66

There will be no further upstream releases to Ruby 3.2, thus we have to upgrade this gem ourselves. The 0.5.0 and 0.6.0 releases have some breaking changes, however the `net-imap` gem was completely broken in OpenVox 8 for quite a few release without any issue reports -- which suggests low usage.

The 0.6 release series was selected as support has ended for the 0.4 line and this syncs OpenVox 8 behavior with Ruby 4 in OpenVox 9.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
