### PR TITLE
Ignore base64 gem during update_gems workflow

### DIFF
--- a/tasks/update_gems.rake
+++ b/tasks/update_gems.rake
@@ -27,7 +27,7 @@ TARGET_RUBY_VER = ENV['TARGET_RUBY']&.strip || '3.2'
 # gems that we specifically want to manage even if they are default or bundled.
 DEFAULT_AND_BUNDLED_GEMS = [
   'abbrev',
-  # 'base64',
+  'base64',
   'benchmark',
   'bigdecimal',
   'bundler',


### PR DESCRIPTION
### Short description

Prior to this commit, the `update_gems` workflow would add a `pkg.build_requires 'base64'` statement when updating gem components. This would cause the update to fail tests as `apt install rubygems-base64` or `dnf install rubygems-base64` doesn't work on many platforms.

This commit restores `base64` to an "ignored" status as it is, depending on Ruby version, a default or bundled gem that is always present in the installation in some form. There may be issues surrounding `base64`, but it seems better for a human to sort those out manually than for automation to repeatedly make the wrong decision every day at midnight.

This partially reverts commit 2dcd0dbb4eb0d5f3f690f8162bd8ac5d9487133a.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
