### PR TITLE
Update update components

### DIFF
--- a/tasks/update_components.rake
+++ b/tasks/update_components.rake
@@ -24,7 +24,8 @@ def github_owner_repo(url)
   [Regexp.last_match(1), Regexp.last_match(2).sub(/\.git$/, '')]
 end
 
-# Normalize a version string by stripping common tag prefixes.
+# Normalize a version string by stripping common tag prefixes and
+# replacing underscores with .
 def normalize_version(tag)
   return nil if tag.nil?
 
@@ -32,6 +33,8 @@ def normalize_version(tag)
      .sub(/\Arefs\/tags\/v?/, '')
      .sub(/\Arelease-/, '')
      .sub(/\Aopenssl-/, '')
+     .sub(/\Acurl-/, '')
+     .gsub('_', '.')
 end
 
 # Try to parse a version from a normalized string, returning nil if unparseable.

--- a/tasks/update_components.rake
+++ b/tasks/update_components.rake
@@ -26,6 +26,8 @@ end
 
 # Normalize a version string by stripping common tag prefixes.
 def normalize_version(tag)
+  return nil if tag.nil?
+
   tag.sub(/\Av(?=\d)/, '')
      .sub(/\Arefs\/tags\/v?/, '')
      .sub(/\Arelease-/, '')
@@ -50,11 +52,12 @@ end
 # and somme people, like openssl, maintain multiple streams. So the latest tag might not be the highest version
 # We do some version comparison to find the actual highest version
 def latest_github_tag(owner, repo)
-  github_client.tags("#{owner}/#{repo}", per_page: 100)
-               .map { |tag| [tag.name, try_version(normalize_version(tag.name))] }
-               .reject { |_, version| version.nil? || version.prerelease? }
-               .max_by { |_, version| version }
-               .first
+  tags = github_client.tags("#{owner}/#{repo}", per_page: 100)
+                      .map { |tag| [tag.name, try_version(normalize_version(tag.name))] }
+                      .reject { |_, version| version.nil? || version.prerelease? }
+                      .max_by { |_, version| version }
+
+  tags.nil? ? tags : tags.first
 end
 
 def current_version(data)


### PR DESCRIPTION
### Short description

This changeset updates the ` rake vox:update_outdated_components` task to handle repos with no tags and the `curl-X_Y_Z` tag format used by the `curl` project.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
