### PR TITLE
Pin bindata gem to 2.5.1

### DIFF
--- a/configs/components/rubygem-bindata.rb
+++ b/configs/components/rubygem-bindata.rb
@@ -5,6 +5,7 @@
 #####
 component 'rubygem-bindata' do |pkg, _settings, _platform|
   ### Maintained by update_gems automation ###
+  # PINNED
   pkg.version '2.5.1'
   pkg.sha256sum '53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58'
   ### End automated maintenance section ###


### PR DESCRIPTION
### Short description

The `bindata` project just released a new 3.0 major version, but we are currently pinned to an old `ruby_smb` release, which depends on this gem.


### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
