### PR TITLE
Rebrand Puppet -> OpenVox in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # puppet-runtime
 
 The puppet-runtime exists to build vendored components for
-[Puppet](https://github.com/puppetlabs) projects and distribute them as a
+[OpenVox](https://github.com/OpenVoxProject) projects and distribute them as a
 tarball for reuse. Runtime projects are built with
-[vanagon](https://github.com/puppetlabs/vanagon), a packaging utility.
+[vanagon](https://github.com/OpenVoxProject/vanagon), a packaging utility.
 
 Available components include curl, openssl, ruby, and more - see the
 [configs/components directory](configs/components) for a full list. Individual
@@ -24,7 +24,7 @@ First, install the gem dependencies:
 $ bundle install
 ```
 
-Next, if you are building on infrastructure outside of Puppet, you will need to
+Next, if you are building on infrastructure outside of the OpenVox Project, you will need to
 modify some package dependency names in the [configs directory](configs). Any
 references to pl-gcc, pl-cmake, pl-yaml-cpp, etc. in these files will need to
 be changed to refer to equivalent installable packages on your target platform.
@@ -36,10 +36,10 @@ repository you need to build. This will depend on the target repository that
 consumes your finished runtime. In some cases, there is only one runtime
 project available (`runtime-pdk`, for example, is the only runtime for the
 PDK). In other cases, the runtime project to build may depend on the branch of
-the target repository that consumes the runtime. For example, puppet-agent is
+the target repository that consumes the runtime. For example, openvox-agent is
 developed on multiple git branches; You should select the runtime project that
 matches the target branch (for instance, you would build `agent-runtime-5.3.x`
-for use with puppet-agent's 5.3.x branch).  See the
+for use with openvox-agent's 5.3.x branch).  See the
 [configs/projects](configs/projects) directory for a full list of options.
 
 You can build the project using vanagon like this:

--- a/configs/components/openssl-3.0.rb
+++ b/configs/components/openssl-3.0.rb
@@ -78,9 +78,9 @@ component 'openssl' do |pkg, settings, platform|
     'no-dtls1-method',
     'no-dtls1_2-method',
     'no-aria',
-    # 'no-bf', pgcrypto is requires this cipher in postgres for puppetdb
-    # 'no-cast', pgcrypto is requires this cipher in postgres for puppetdb
-    # 'no-des', pgcrypto is requires this cipher in postgres for puppetdb,
+    # 'no-bf', pgcrypto is requires this cipher in postgres for OpenVoxDB
+    # 'no-cast', pgcrypto is requires this cipher in postgres for OpenVoxDB
+    # 'no-des', pgcrypto is requires this cipher in postgres for OpenVoxDB,
     # should pgcrypto cease needing it, it will also be needed by ntlm
     # and should only be enabled if "use_legacy_openssl_algos" is true.
     'no-rc5',

--- a/configs/projects/_shared-agent-settings.rb
+++ b/configs/projects/_shared-agent-settings.rb
@@ -1,4 +1,4 @@
-# This "project" is designed to be shared by all puppet-agent projects
+# This "project" is designed to be shared by all openvox-agent projects
 # See configs/projects/agent-runtime-<branchname>.rb
 unless defined?(proj)
   warn('These are base settings shared by all puppet-agent projects; They cannot be built as a standalone project.')
@@ -14,7 +14,7 @@ proj.publish_yaml_settings
 proj.setting(:runtime_project, 'agent')
 
 ########
-# Common build settings for all versions of puppet-agent
+# Common build settings for all versions of openvox-agent
 ########
 
 proj.generate_archives true
@@ -162,7 +162,7 @@ proj.identifier 'org.voxpupuli' if platform.is_macos?
 
 proj.timeout 7200 if platform.is_windows?
 
-# Most branches of puppet-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
+# Most branches of openvox-agent use these openssl flags in addition to the defaults in configs/components/openssl.rb -
 # Individual projects can override these if necessary.
 unless proj.settings[:openssl_extra_configure_flags]
   proj.setting(:openssl_extra_configure_flags, [

--- a/configs/projects/openbolt-runtime.rb
+++ b/configs/projects/openbolt-runtime.rb
@@ -125,7 +125,7 @@ project 'openbolt-runtime' do |proj|
   proj.component 'rubygem-bcrypt_pbkdf'
   proj.component 'rubygem-ed25519'
 
-  # Puppet dependencies
+  # OpenVox dependencies
   proj.component 'rubygem-hocon'
   proj.component 'rubygem-deep_merge'
   proj.component 'rubygem-text'


### PR DESCRIPTION
### Short description
Rebrand user-facing product references in README prose and build-config code comments: Puppet -> OpenVox, puppet-agent -> openvox-agent (prose only), puppetdb -> OpenVoxDB. Point README project/vanagon links at the OpenVoxProject GitHub org (matching the vanagon fork pinned in the Gemfile).

Deliberately unchanged: all load-bearing identifiers - repo and runtime project names (puppet-runtime, agent-runtime-*, pdb-runtime), component and package names, file paths (/opt/puppetlabs, Puppet Labs on Windows), Windows pl_product_id/pl_company_id settings, proj.description strings, warn() message strings, executable/service names (puppet, facter, puppetserver), source URLs, checksums, patches, CHANGELOG history, and third-party attributions.

_Generated by Claude Code_

### Checklist
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
