### PR TITLE
aws CLI: use OS CA bundle

### DIFF
--- a/tasks/upload.rake
+++ b/tasks/upload.rake
@@ -11,7 +11,7 @@ namespace :vox do
     abort 'You must provide a tag.' if args[:tag].nil? || args[:tag].empty?
 
     munged_tag = args[:tag].gsub('-', '.')
-    s3 = "aws s3 --endpoint-url=#{endpoint}"
+    s3 = "aws s3 --endpoint-url=#{endpoint} --ca-bundle /etc/ssl/certs/ca-certificates.crt"
 
     # Ensure the AWS CLI isn't going to fail with the given parameters
     run_command("#{s3} ls s3://#{bucket}/")


### PR DESCRIPTION
Our S3 bucket has a new certificates. aws CLI ships a CA bundle and that's outdated. We did the same here: https://github.com/OpenVoxProject/openvox-release-infra/pull/25/

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
