### PR TITLE
Revert "aws CLI: use OS CA bundle"

### DIFF
--- a/tasks/upload.rake
+++ b/tasks/upload.rake
@@ -11,7 +11,7 @@ namespace :vox do
     abort 'You must provide a tag.' if args[:tag].nil? || args[:tag].empty?
 
     munged_tag = args[:tag].gsub('-', '.')
-    s3 = "aws s3 --endpoint-url=#{endpoint} --ca-bundle /etc/ssl/certs/ca-certificates.crt"
+    s3 = "aws s3 --endpoint-url=#{endpoint}"
 
     # Ensure the AWS CLI isn't going to fail with the given parameters
     run_command("#{s3} ls s3://#{bucket}/")


### PR DESCRIPTION
### Short description

Using "--ca-bundle /etc/ssl/certs/ca-certificates.crt" only works on Ubuntu. Other Linux OSes store certificates in different locations, and macOS and Windows don't use files to store the list of trusted CAs.

This commit reverts the addition of the "--ca-bundle" flag in Rake task logic in favor of setting the `AWS_CA_BUNDLE` environment variable, which has been done at the workflow level in:

  OpenVoxProject/shared-actions#118

This reverts commit 0174517447ca9745c5e349f9591c96af8d6ca242.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [x] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)